### PR TITLE
run: Improve message when client creation fails

### DIFF
--- a/internal/run/wrapper.go
+++ b/internal/run/wrapper.go
@@ -26,7 +26,7 @@ func NewAPIClient(ctx context.Context, region string) (*API, error) {
 	regionalEndpoint := fmt.Sprintf("https://%s-run.googleapis.com/", region)
 	client, err := run.NewService(ctx, option.WithEndpoint(regionalEndpoint))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not initialize a APIService instance")
+		return nil, errors.Wrap(err, "could not initialize client for the Cloud Run API")
 	}
 
 	return &API{


### PR DESCRIPTION
The error message was based on the implementation of the package, and so it could be confusing to someone not familiar with the code.