### PR TITLE
mock: Create an internal mock package

### DIFF
--- a/internal/mock/run.go
+++ b/internal/mock/run.go
@@ -2,8 +2,8 @@ package mock
 
 import "google.golang.org/api/run/v1"
 
-// RunAPI represents a mock implementation of run.API.
-type RunAPI struct {
+// Run represents a mock implementation of run.API.
+type Run struct {
 	ServiceFn      func(namespace, serviceID string) (*run.Service, error)
 	ServiceInvoked bool
 
@@ -12,13 +12,13 @@ type RunAPI struct {
 }
 
 // Service invokes the mock implementation and marks the function as invoked.
-func (a *RunAPI) Service(namespace, service string) (*run.Service, error) {
+func (a *Run) Service(namespace, service string) (*run.Service, error) {
 	a.ServiceInvoked = true
 	return a.ServiceFn(namespace, service)
 }
 
 // ReplaceService invokes the mock implementation and marks the function as invoked.
-func (a *RunAPI) ReplaceService(namespace, serviceID string, svc *run.Service) (*run.Service, error) {
+func (a *Run) ReplaceService(namespace, serviceID string, svc *run.Service) (*run.Service, error) {
 	a.ReplaceServiceInvoked = true
 	return a.ReplaceServiceFn(namespace, serviceID, svc)
 }

--- a/internal/mock/run.go
+++ b/internal/mock/run.go
@@ -12,13 +12,13 @@ type Run struct {
 }
 
 // Service invokes the mock implementation and marks the function as invoked.
-func (a *Run) Service(namespace, service string) (*run.Service, error) {
-	a.ServiceInvoked = true
-	return a.ServiceFn(namespace, service)
+func (r *Run) Service(namespace, service string) (*run.Service, error) {
+	r.ServiceInvoked = true
+	return r.ServiceFn(namespace, service)
 }
 
 // ReplaceService invokes the mock implementation and marks the function as invoked.
-func (a *Run) ReplaceService(namespace, serviceID string, svc *run.Service) (*run.Service, error) {
-	a.ReplaceServiceInvoked = true
-	return a.ReplaceServiceFn(namespace, serviceID, svc)
+func (r *Run) ReplaceService(namespace, serviceID string, svc *run.Service) (*run.Service, error) {
+	r.ReplaceServiceInvoked = true
+	return r.ReplaceServiceFn(namespace, serviceID, svc)
 }

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/run/mock"
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/mock"
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/config"
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/rollout"
 	"github.com/google/go-cmp/cmp"
@@ -35,7 +35,7 @@ func generateService(opts *ServiceOpts) *run.Service {
 }
 
 func TestUpdateService(t *testing.T) {
-	runclient := &mock.RunAPI{}
+	runclient := &mock.Run{}
 	strategy := &config.Strategy{
 		Steps: []int64{10, 40, 70},
 	}
@@ -197,7 +197,7 @@ func TestUpdateService(t *testing.T) {
 }
 
 func TestSplitTraffic(t *testing.T) {
-	runclient := &mock.RunAPI{}
+	runclient := &mock.Run{}
 	strategy := &config.Strategy{
 		Steps: []int64{5, 30, 60},
 	}


### PR DESCRIPTION
This creates a new internal package for mocks. This will be more useful as we add mocks for the metrics and health package (maybe others) in the future.