### PR TITLE
config: Add metrics checks in configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,12 +1,12 @@
 package config
 
-// MetricsCheck is metrics check type.
+// MetricsCheck is the metrics check type.
 type MetricsCheck string
 
 // Supported metrics checks.
 const (
-	LatencyCheckType MetricsCheck = "request-latency"
-	ErrorCheckType                = "error-rate"
+	LatencyMetricsCheck MetricsCheck = "request-latency"
+	ErrorMetricsCheck                = "error-rate"
 )
 
 // Target is the configuration to filter services.
@@ -24,18 +24,19 @@ type Target struct {
 	LabelSelector string
 }
 
-// Check is a metrics threshold that should be met to consider a candidate
+// Metric is a metrics threshold that should be met to consider a candidate
 // healthy.
-type Check struct {
+type Metric struct {
 	Type       MetricsCheck
 	Percentile float64
+	Min        float64
 	Max        float64
 }
 
 // Strategy is the steps and configuration for rollout.
 type Strategy struct {
-	Steps  []int64
-	Checks []Check
+	Steps   []int64
+	Metrics []Metric
 
 	// TODO: Give this property a clearer name.
 	Interval int64

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,5 +1,14 @@
 package config
 
+// MetricsCheck is metrics check type.
+type MetricsCheck string
+
+// Supported metrics checks.
+const (
+	LatencyCheckType MetricsCheck = "request-latency"
+	ErrorCheckType                = "error-rate"
+)
+
 // Target is the configuration to filter services.
 //
 // A target might have the following form
@@ -15,9 +24,18 @@ type Target struct {
 	LabelSelector string
 }
 
+// Check is a metrics threshold that should be met to consider a candidate
+// healthy.
+type Check struct {
+	Type       MetricsCheck
+	Percentile float64
+	Max        float64
+}
+
 // Strategy is the steps and configuration for rollout.
 type Strategy struct {
-	Steps []int64
+	Steps  []int64
+	Checks []Check
 
 	// TODO: Give this property a clearer name.
 	Interval int64

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,7 +6,7 @@ type MetricsCheck string
 // Supported metrics checks.
 const (
 	LatencyMetricsCheck MetricsCheck = "request-latency"
-	ErrorMetricsCheck                = "error-rate"
+	ErrorMetricsCheck                = "error-rate-percent"
 )
 
 // Target is the configuration to filter services.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,8 +5,8 @@ type MetricsCheck string
 
 // Supported metrics checks.
 const (
-	LatencyMetricsCheck MetricsCheck = "request-latency"
-	ErrorMetricsCheck                = "error-rate-percent"
+	LatencyMetricsCheck   MetricsCheck = "request-latency"
+	ErrorRateMetricsCheck              = "error-rate-percent"
 )
 
 // Target is the configuration to filter services.


### PR DESCRIPTION
This allows to specify metrics checks in the configuration. This will be used by the health package to determine if the candidate meets the metrics checks criteria