### PR TITLE
metrics: Obtain request count

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -24,18 +24,17 @@ const (
 )
 
 // Metrics represents a monitoring API such as Stackdriver.
-//
-// RequestCount count returns the number of requests for the given offset and
-// query.
-//
-// Latency returns the request latency after applying the specified series
-// aligner and cross series reducer. The result is in milliseconds.
-//
-// Error rate gets all the server responses. It calculates the error rate by
-// performing the operation (5xx responses / all responses).
 type Metrics interface {
+	// RequestCount count returns the number of requests for the given offset
+	// and query.
 	RequestCount(ctx context.Context, query Query, offset time.Duration) (int64, error)
+
+	// Latency returns the request latency after applying the specified series
+	// aligner and cross series reducer. The result is in milliseconds.
 	Latency(ctx context.Context, query Query, offset time.Duration, alignReduceType AlignReduce) (float64, error)
+
+	// Error rate gets all the server responses. It calculates the error rate by
+	// performing the operation (5xx responses / all responses).
 	ErrorRate(ctx context.Context, query Query, offset time.Duration) (float64, error)
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -25,12 +25,16 @@ const (
 
 // Metrics represents a monitoring API such as Stackdriver.
 //
+// RequestCount count returns the number of requests for the given offset and
+// query.
+//
 // Latency returns the request latency after applying the specified series
 // aligner and cross series reducer. The result is in milliseconds.
 //
 // Error rate gets all the server responses. It calculates the error rate by
 // performing the operation (5xx responses / all responses).
 type Metrics interface {
+	RequestCount(ctx context.Context, query Query, offset time.Duration) (int64, error)
 	Latency(ctx context.Context, query Query, offset time.Duration, alignReduceType AlignReduce) (float64, error)
 	ErrorRate(ctx context.Context, query Query, offset time.Duration) (float64, error)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -25,16 +25,15 @@ const (
 
 // Metrics represents a monitoring API such as Stackdriver.
 type Metrics interface {
-	// RequestCount count returns the number of requests for the given offset
-	// and query.
+	// Returns the number of requests for the given offset and query.
 	RequestCount(ctx context.Context, query Query, offset time.Duration) (int64, error)
 
-	// Latency returns the request latency after applying the specified series
-	// aligner and cross series reducer. The result is in milliseconds.
+	// Returns the request latency after applying the specified series aligner
+	// and cross series reducer. The result is in milliseconds.
 	Latency(ctx context.Context, query Query, offset time.Duration, alignReduceType AlignReduce) (float64, error)
 
-	// Error rate gets all the server responses. It calculates the error rate by
-	// performing the operation (5xx responses / all responses).
+	// Gets all the server responses and calculates the error rate by performing
+	// the operation (5xx responses / all responses).
 	ErrorRate(ctx context.Context, query Query, offset time.Duration) (float64, error)
 }
 

--- a/internal/metrics/mock/metrics.go
+++ b/internal/metrics/mock/metrics.go
@@ -9,6 +9,9 @@ import (
 
 // Metrics is a mock implementation of metrics.Metrics.
 type Metrics struct {
+	RequestCountFn      func(ctx context.Context, query metrics.Query, offset time.Duration) (int64, error)
+	RequestCountInvoked bool
+
 	LatencyFn      func(ctx context.Context, query metrics.Query, offset time.Duration, alignReduceType metrics.AlignReduce) (float64, error)
 	LatencyInvoked bool
 
@@ -18,6 +21,12 @@ type Metrics struct {
 
 // Query is a mock implementation of metrics.Query.
 type Query struct{}
+
+// RequestCount invokes the mock implementation and marks the function as invoked.
+func (m *Metrics) RequestCount(ctx context.Context, query metrics.Query, offset time.Duration) (int64, error) {
+	m.RequestCountInvoked = true
+	return m.RequestCountFn(ctx, query, offset)
+}
 
 // Latency invokes the mock implementation and marks the function as invoked.
 func (m *Metrics) Latency(ctx context.Context, query metrics.Query, offset time.Duration, alignReduceType metrics.AlignReduce) (float64, error) {

--- a/internal/stackdriver/stackdriver.go
+++ b/internal/stackdriver/stackdriver.go
@@ -68,7 +68,7 @@ func (a *API) RequestCount(ctx context.Context, query Query, offset time.Duratio
 	for {
 		series, err := it.Next()
 
-		// If this is hit first, it means that no request were made during the
+		// If this is hit first, it means that no request was made during the
 		// given offset.
 		if err == iterator.Done {
 			return 0, nil


### PR DESCRIPTION
This adds a function to the Metrics interface and adds an implementation in stackdriver to obtain the number of requests for a given offset.