### PR TITLE
run: Log when cached regions are used

### DIFF
--- a/cmd/operator/service.go
+++ b/cmd/operator/service.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	runapi "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/run"
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/util"
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/config"
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/rollout"
 	"github.com/pkg/errors"
@@ -94,6 +95,7 @@ func determineRegions(ctx context.Context, logger *logrus.Logger, target *config
 
 	logger.Debug("retrieving all regions from the API")
 
+	ctx = util.ContextWithLogger(ctx, logger)
 	regions, err := runapi.Regions(ctx, target.Project)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot get list of regions from Cloud Run API")

--- a/cmd/operator/service.go
+++ b/cmd/operator/service.go
@@ -95,7 +95,8 @@ func determineRegions(ctx context.Context, logger *logrus.Logger, target *config
 
 	logger.Debug("retrieving all regions from the API")
 
-	ctx = util.ContextWithLogger(ctx, logger)
+	lg := logrus.NewEntry(logger)
+	ctx = util.ContextWithLogger(ctx, lg)
 	regions, err := runapi.Regions(ctx, target.Project)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot get list of regions from Cloud Run API")

--- a/internal/run/wrapper.go
+++ b/internal/run/wrapper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/util"
 	"github.com/pkg/errors"
 	"google.golang.org/api/option"
 	"google.golang.org/api/run/v1"
@@ -67,7 +68,9 @@ func (a *API) ServicesWithLabelSelector(namespace string, labelSelector string) 
 
 // Regions gets the supported regions for the project.
 func Regions(ctx context.Context, project string) ([]string, error) {
+	logger := util.LoggerFromContext(ctx)
 	if len(regions) != 0 {
+		logger.Debug("using cached regions, skip querying from API")
 		return regions, nil
 	}
 

--- a/internal/util/context.go
+++ b/internal/util/context.go
@@ -13,12 +13,16 @@ var loggerKey contextKeyLogger
 
 // ContextWithLogger returns a copy of the parent context that includes the
 // logger.
-func ContextWithLogger(ctx context.Context, logger *logrus.Logger) context.Context {
+func ContextWithLogger(ctx context.Context, logger *logrus.Entry) context.Context {
 	return context.WithValue(ctx, loggerKey, logger)
 }
 
 // LoggerFromContext returns the logger from the context.
-func LoggerFromContext(ctx context.Context) *logrus.Logger {
-	logger := ctx.Value(loggerKey).(*logrus.Logger)
+func LoggerFromContext(ctx context.Context) *logrus.Entry {
+	logger := ctx.Value(loggerKey).(*logrus.Entry)
+	if logger == nil {
+		logger = logrus.NewEntry(logrus.New())
+	}
+
 	return logger
 }

--- a/internal/util/context.go
+++ b/internal/util/context.go
@@ -6,21 +6,19 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type contextKey string
+type contextKeyLogger struct{}
 
-// Context keys.
-const (
-	contextKeyLogger = contextKey("logger")
-)
+// The logger context key
+var loggerKey contextKeyLogger
 
 // ContextWithLogger returns a copy of the parent context that includes the
 // logger.
 func ContextWithLogger(ctx context.Context, logger *logrus.Logger) context.Context {
-	return context.WithValue(ctx, contextKeyLogger, logger)
+	return context.WithValue(ctx, loggerKey, logger)
 }
 
 // LoggerFromContext returns the logger from the context.
 func LoggerFromContext(ctx context.Context) *logrus.Logger {
-	logger := ctx.Value(contextKeyLogger).(*logrus.Logger)
+	logger := ctx.Value(loggerKey).(*logrus.Logger)
 	return logger
 }

--- a/internal/util/context.go
+++ b/internal/util/context.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+)
+
+type contextKey string
+
+// Context keys.
+const (
+	contextKeyLogger = contextKey("logger")
+)
+
+// ContextWithLogger returns a copy of the parent context that includes the
+// logger.
+func ContextWithLogger(ctx context.Context, logger *logrus.Logger) context.Context {
+	return context.WithValue(ctx, contextKeyLogger, logger)
+}
+
+// LoggerFromContext returns the logger from the context.
+func LoggerFromContext(ctx context.Context) *logrus.Logger {
+	logger := ctx.Value(contextKeyLogger).(*logrus.Logger)
+	return logger
+}


### PR DESCRIPTION
This lets the developer know that the list of regions were obtained from a cache. It also adds utility functions to set and get loggers to and from a context, which will also become useful when logging information about health and metrics.