### PR TITLE
metrics: Convert percentile to align/reduce value

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -3,6 +3,8 @@ package metrics
 import (
 	"context"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // Query is the filter used to retrieve metrics data.
@@ -31,4 +33,22 @@ const (
 type Metrics interface {
 	Latency(ctx context.Context, query Query, offset time.Duration, alignReduceType AlignReduce) (float64, error)
 	ErrorRate(ctx context.Context, query Query, offset time.Duration) (float64, error)
+}
+
+// PercentileToAlignReduce takes a percentile value maps it to a AlignReduce
+// value.
+//
+// TODO: once we start supporting any percentile value, this should not be
+// needed.
+func PercentileToAlignReduce(percentile float64) (AlignReduce, error) {
+	switch percentile {
+	case 99:
+		return Align99Reduce99, nil
+	case 95:
+		return Align95Reduce95, nil
+	case 50:
+		return Align50Reduce50, nil
+	default:
+		return 0, errors.Errorf("unsupported percentile value %.2f", percentile)
+	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -46,7 +46,7 @@ func PercentileToAlignReduce(percentile float64) (AlignReduce, error) {
 		return Align99Reduce99, nil
 	case 95:
 		return Align95Reduce95, nil
-	case 50.0:
+	case 50:
 		return Align50Reduce50, nil
 	default:
 		return 0, errors.Errorf("unsupported percentile value %.2f", percentile)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -46,7 +46,7 @@ func PercentileToAlignReduce(percentile float64) (AlignReduce, error) {
 		return Align99Reduce99, nil
 	case 95:
 		return Align95Reduce95, nil
-	case 50:
+	case 50.0:
 		return Align50Reduce50, nil
 	default:
 		return 0, errors.Errorf("unsupported percentile value %.2f", percentile)

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,73 @@
+package metrics_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPercentileToAlignReduce(t *testing.T) {
+	tests := []struct {
+		name       string
+		percentile float64
+		expected   metrics.AlignReduce
+		shouldErr  bool
+	}{
+		{
+			name:       "99.0 (99th percentile)",
+			percentile: 99.0,
+			expected:   metrics.Align99Reduce99,
+		},
+		{
+			name:       "99 (99th percentile)",
+			percentile: 99,
+			expected:   metrics.Align99Reduce99,
+		},
+		{
+			name:       "99.01 (invalid)",
+			percentile: 99.01,
+			shouldErr:  true,
+		},
+		{
+			name:       "95.0 (95th percentile)",
+			percentile: 95.0,
+			expected:   metrics.Align95Reduce95,
+		},
+		{
+			name:       "95.01 (invalid)",
+			percentile: 95.01,
+			shouldErr:  true,
+		},
+		{
+			name:       "50 (50th percentile)",
+			percentile: 50,
+			expected:   metrics.Align50Reduce50,
+		},
+		{
+			name:       "50.01 (invalid)",
+			percentile: 50.01,
+			shouldErr:  true,
+		},
+		{
+			name:       "49.99999 (invalid)",
+			percentile: 49.99999,
+			shouldErr:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			alignReducer, err := metrics.PercentileToAlignReduce(test.percentile)
+			if test.shouldErr {
+				if err == nil {
+					fmt.Println(alignReducer)
+				}
+				assert.NotNil(t, err)
+			} else {
+				assert.Equal(t, test.expected, alignReducer)
+			}
+		})
+	}
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,7 +1,6 @@
 package metrics_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/metrics"
@@ -61,9 +60,6 @@ func TestPercentileToAlignReduce(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			alignReducer, err := metrics.PercentileToAlignReduce(test.percentile)
 			if test.shouldErr {
-				if err == nil {
-					fmt.Println(alignReducer)
-				}
 				assert.NotNil(t, err)
 			} else {
 				assert.Equal(t, test.expected, alignReducer)


### PR DESCRIPTION
This adds a function to convert a supported percentile to an equivalent value for time series aligner/reducer