### PR TITLE
main: Support metrics flags

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -197,7 +197,6 @@ func flagsAreValid() (bool, error) {
 // config.Metric based on them.
 func metricsFromFlags(errorRate, latencyP99, latencyP95, latencyP50 float64) []config.Metric {
 	var metrics []config.Metric
-
 	metrics = append(metrics, config.Metric{Type: config.ErrorRateMetricsCheck, Max: errorRate})
 
 	if latencyP99 > 0 {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,11 +52,12 @@ type Config struct {
 }
 
 // WithValues initializes a configuration with the given values.
-func WithValues(targets []*Target, steps []int64, interval int64) *Config {
+func WithValues(targets []*Target, steps []int64, interval int64, metrics []Metric) *Config {
 	return &Config{
 		Targets: targets,
 		Strategy: &Strategy{
 			Steps:    steps,
+			Metrics:  metrics,
 			Interval: interval,
 		},
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,7 +18,7 @@ func TestIsValid(t *testing.T) {
 			name: "correct config with label selector",
 			config: config.WithValues([]*config.Target{
 				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
-			}, []int64{5, 30, 60}, 20),
+			}, []int64{5, 30, 60}, 20, nil),
 			cliMode:  true,
 			expected: true,
 		},
@@ -27,7 +27,7 @@ func TestIsValid(t *testing.T) {
 			name: "missing project",
 			config: config.WithValues([]*config.Target{
 				config.NewTarget("", []string{"us-east1", "us-west1"}, "team=backend"),
-			}, []int64{5, 30, 60}, 20),
+			}, []int64{5, 30, 60}, 20, nil),
 			cliMode:  true,
 			expected: false,
 		},
@@ -36,7 +36,7 @@ func TestIsValid(t *testing.T) {
 			name: "missing steps",
 			config: config.WithValues([]*config.Target{
 				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
-			}, []int64{}, 20),
+			}, []int64{}, 20, nil),
 			cliMode:  true,
 			expected: false,
 		},
@@ -45,7 +45,7 @@ func TestIsValid(t *testing.T) {
 			name: "steps not in order",
 			config: config.WithValues([]*config.Target{
 				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
-			}, []int64{30, 30, 60}, 20),
+			}, []int64{30, 30, 60}, 20, nil),
 			cliMode:  true,
 			expected: false,
 		},
@@ -54,7 +54,7 @@ func TestIsValid(t *testing.T) {
 			name: "step greater than 100",
 			config: config.WithValues([]*config.Target{
 				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
-			}, []int64{5, 30, 101}, 20),
+			}, []int64{5, 30, 101}, 20, nil),
 			cliMode:  true,
 			expected: false,
 		},
@@ -63,7 +63,7 @@ func TestIsValid(t *testing.T) {
 			name: "no interval for cli mode",
 			config: config.WithValues([]*config.Target{
 				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
-			}, []int64{5, 30, 60}, 0),
+			}, []int64{5, 30, 60}, 0, nil),
 			cliMode:  true,
 			expected: false,
 		},
@@ -72,7 +72,7 @@ func TestIsValid(t *testing.T) {
 			name: "empty label selector",
 			config: config.WithValues([]*config.Target{
 				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, ""),
-			}, []int64{5, 30, 60}, 20),
+			}, []int64{5, 30, 60}, 20, nil),
 			cliMode:  true,
 			expected: false,
 		},


### PR DESCRIPTION
This adds support for metrics-related flags for health check. The new flags are: `-error-rate` (percent), `latency-p99` (ms), `latency-p95` (ms), and `latency-p50` (ms).
