### PR TITLE
stackdriver: Use package with RPC for MQL query

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoogleCloudPlatform/cloud-run-release-operator
 go 1.14
 
 require (
-	cloud.google.com/go v0.60.0
+	cloud.google.com/go v0.60.0 // indirect
 	github.com/TV4/logrus-stackdriver-formatter v0.1.0
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/google/go-cmp v0.5.0
@@ -11,7 +11,5 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.6.1
-	google.golang.org/api v0.29.0
-	google.golang.org/genproto v0.0.0-20200711021454-869866162049
-	google.golang.org/protobuf v1.25.0
+	google.golang.org/api v0.28.0
 )

--- a/go.sum
+++ b/go.sum
@@ -303,8 +303,6 @@ google.golang.org/api v0.22.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/
 google.golang.org/api v0.24.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
 google.golang.org/api v0.28.0 h1:jMF5hhVfMkTZwHW1SDpKq5CkgWLXOb31Foaca9Zr3oM=
 google.golang.org/api v0.28.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
-google.golang.org/api v0.29.0 h1:BaiDisFir8O4IJxvAabCGGkQ6yCJegNQqSVoYUNAnbk=
-google.golang.org/api v0.29.0/go.mod h1:Lcubydp8VUV7KeIHD9z2Bys/sm/vGKnG1UHuDBSrHWM=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -339,9 +337,8 @@ google.golang.org/genproto v0.0.0-20200430143042-b979b6f78d84/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200511104702-f5ebc3bea380/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
+google.golang.org/genproto v0.0.0-20200626011028-ee7919e894b5 h1:a/Sqq5B3dGnmxhuJZIHFsIxhEkqElErr5TaU6IqBAj0=
 google.golang.org/genproto v0.0.0-20200626011028-ee7919e894b5/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20200711021454-869866162049 h1:YFTFpQhgvrLrmxtiIncJxFXeCyq84ixuKWVCaCAi9Oc=
-google.golang.org/genproto v0.0.0-20200711021454-869866162049/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/internal/stackdriver/stackdriver.go
+++ b/internal/stackdriver/stackdriver.go
@@ -5,19 +5,18 @@ import (
 	"fmt"
 	"time"
 
-	monitoring "cloud.google.com/go/monitoring/apiv3"
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/metrics"
 	"github.com/pkg/errors"
-	"google.golang.org/api/iterator"
-	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
-	duration "google.golang.org/protobuf/types/known/durationpb"
-	timestamp "google.golang.org/protobuf/types/known/timestamppb"
+
+	// TODO: Migrate to cloud.google.com/go/monitoring/apiv3/v2 once RPC for MQL
+	// query is added (https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.timeSeries/query).
+	monitoring "google.golang.org/api/monitoring/v3"
 )
 
 // API is a wrapper for the Cloud Monitoring package.
 type API struct {
-	*monitoring.MetricClient
-	Project string
+	MetricClient *monitoring.Service
+	Project      string
 }
 
 // Query is the filter used to retrieve metrics data.
@@ -33,7 +32,7 @@ const (
 
 // NewAPIClient initializes
 func NewAPIClient(ctx context.Context, project string) (*API, error) {
-	client, err := monitoring.NewMetricClient(ctx)
+	client, err := monitoring.NewService(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not initialize Cloud Metics client")
 	}
@@ -48,68 +47,67 @@ func NewAPIClient(ctx context.Context, project string) (*API, error) {
 func (a *API) Latency(ctx context.Context, query metrics.Query, offset time.Duration, alignReduceType metrics.AlignReduce) (float64, error) {
 	query = addFilterToQuery(query, "metric.type", requestLatencies)
 	endTime := time.Now()
-	startTime := time.Now().Add(-1 * offset)
+	startTime := endTime.Add(-1 * offset)
 	aligner, reducer := alignerAndReducer(alignReduceType)
+	offsetString := fmt.Sprintf("%fs", offset.Seconds())
 
-	it := a.MetricClient.ListTimeSeries(ctx, &monitoringpb.ListTimeSeriesRequest{
-		Name:   "projects/" + a.Project,
-		Filter: query.Query(),
-		Interval: &monitoringpb.TimeInterval{
-			StartTime: timestamp.New(startTime),
-			EndTime:   timestamp.New(endTime),
-		},
-		Aggregation: &monitoringpb.Aggregation{
-			AlignmentPeriod:    duration.New(offset),
-			PerSeriesAligner:   aligner,
-			GroupByFields:      []string{"metric.labels.response_code_class"},
-			CrossSeriesReducer: reducer,
-		},
-	})
+	req := a.MetricClient.Projects.TimeSeries.List("projects/" + a.Project).
+		Filter(query.Query()).
+		IntervalStartTime(startTime.Format(time.RFC3339Nano)).
+		IntervalEndTime(endTime.Format(time.RFC3339Nano)).
+		AggregationAlignmentPeriod(offsetString).
+		AggregationPerSeriesAligner(aligner).
+		AggregationGroupByFields("metric.labels.response_code_class").
+		AggregationCrossSeriesReducer(reducer)
 
-	return latencyForCodeClass(it, "2xx")
+	resp, err := req.Do()
+	if err != nil {
+		return 0, errors.Wrap(err, "error when retrieving time series")
+	}
+	if len(resp.ExecutionErrors) != 0 {
+		return 0, errors.Errorf("execution errors occurred: %v", resp.ExecutionErrors)
+	}
+
+	return latencyForCodeClass(resp.TimeSeries, "2xx")
 }
 
 // ErrorRate returns the rate of 5xx errors for the resource matching the filter.
 func (a *API) ErrorRate(ctx context.Context, query metrics.Query, offset time.Duration) (float64, error) {
 	query = addFilterToQuery(query, "metric.type", requestCount)
 	endTime := time.Now()
-	startTime := time.Now().Add(-1 * offset)
+	startTime := endTime.Add(-1 * offset)
+	offsetString := fmt.Sprintf("%fs", offset.Seconds())
 
-	it := a.MetricClient.ListTimeSeries(ctx, &monitoringpb.ListTimeSeriesRequest{
-		Name:   "projects/" + a.Project,
-		Filter: query.Query(),
-		Interval: &monitoringpb.TimeInterval{
-			StartTime: timestamp.New(startTime),
-			EndTime:   timestamp.New(endTime),
-		},
-		Aggregation: &monitoringpb.Aggregation{
-			AlignmentPeriod:    duration.New(offset),
-			PerSeriesAligner:   monitoringpb.Aggregation_ALIGN_DELTA,
-			GroupByFields:      []string{"metric.labels.response_code_class"},
-			CrossSeriesReducer: monitoringpb.Aggregation_REDUCE_SUM,
-		},
-	})
+	req := a.MetricClient.Projects.TimeSeries.List("projects/" + a.Project).
+		Filter(query.Query()).
+		IntervalStartTime(startTime.Format(time.RFC3339Nano)).
+		IntervalEndTime(endTime.Format(time.RFC3339Nano)).
+		AggregationAlignmentPeriod(offsetString).
+		AggregationPerSeriesAligner("ALIGN_DELTA").
+		AggregationGroupByFields("metric.labels.response_code_class").
+		AggregationCrossSeriesReducer("REDUCE_SUM")
 
-	return calculateErrorResponseRate(it)
+	resp, err := req.Do()
+	if err != nil {
+		return 0, errors.Wrap(err, "error when retrieving time series")
+	}
+	if len(resp.ExecutionErrors) != 0 {
+		return 0, errors.Errorf("execution errors occurred: %v", resp.ExecutionErrors)
+	}
+
+	return calculateErrorResponseRate(resp.TimeSeries)
 }
 
 // latencyForCodeClass retrieves the latency for a given response code class
 // (e.g. 2xx, 5xx, etc.)
-func latencyForCodeClass(it *monitoring.TimeSeriesIterator, codeClass string) (float64, error) {
+func latencyForCodeClass(timeSeries []*monitoring.TimeSeries, codeClass string) (float64, error) {
 	var latency float64
-	for {
-		series, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return 0, errors.Wrap(err, "error when iterating through time series")
-		}
-
+	for _, series := range timeSeries {
 		// Because the interval and the series aligner are the same, only one
 		// point is returned per time series.
 		if series.Metric.Labels["response_code_class"] == codeClass {
-			latency = series.Points[0].Value.GetDoubleValue()
+			latency = *(series.Points[0].Value.DoubleValue)
+			break
 		}
 	}
 
@@ -122,25 +120,17 @@ func latencyForCodeClass(it *monitoring.TimeSeriesIterator, codeClass string) (f
 // add them up to form a 'total'. Then, it divides the number of error responses
 // by the total.
 // It ignores any other type of responses (e.g. 4xx).
-func calculateErrorResponseRate(it *monitoring.TimeSeriesIterator) (float64, error) {
+func calculateErrorResponseRate(timeSeries []*monitoring.TimeSeries) (float64, error) {
 	var errorResponseCount, successfulResponseCount int64
-	for {
-		series, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return 0, errors.Wrap(err, "error when iterating through time series")
-		}
-
+	for _, series := range timeSeries {
 		// Because the interval and the series aligner are the same, only one
 		// point is returned per time series.
 		switch series.Metric.Labels["response_code_class"] {
 		case "5xx":
-			errorResponseCount += series.Points[0].Value.GetInt64Value()
+			errorResponseCount += *(series.Points[0].Value.Int64Value)
 			break
 		default:
-			successfulResponseCount += series.Points[0].Value.GetInt64Value()
+			successfulResponseCount += *(series.Points[0].Value.Int64Value)
 			break
 		}
 	}
@@ -155,19 +145,19 @@ func calculateErrorResponseRate(it *monitoring.TimeSeriesIterator) (float64, err
 	return rate, nil
 }
 
-func alignerAndReducer(alignReduceType metrics.AlignReduce) (aligner monitoringpb.Aggregation_Aligner, reducer monitoringpb.Aggregation_Reducer) {
+func alignerAndReducer(alignReduceType metrics.AlignReduce) (aligner string, reducer string) {
 	switch alignReduceType {
 	case metrics.Align99Reduce99:
-		aligner = monitoringpb.Aggregation_ALIGN_PERCENTILE_99
-		reducer = monitoringpb.Aggregation_REDUCE_PERCENTILE_99
+		aligner = "ALIGN_PERCENTILE_99"
+		reducer = "REDUCE_PERCENTILE_99"
 		break
 	case metrics.Align95Reduce95:
-		aligner = monitoringpb.Aggregation_ALIGN_PERCENTILE_95
-		reducer = monitoringpb.Aggregation_REDUCE_PERCENTILE_95
+		aligner = "ALIGN_PERCENTILE_95"
+		reducer = "REDUCE_PERCENTILE_50"
 		break
 	case metrics.Align50Reduce50:
-		aligner = monitoringpb.Aggregation_ALIGN_PERCENTILE_50
-		reducer = monitoringpb.Aggregation_REDUCE_PERCENTILE_50
+		aligner = "ALIGN_PERCENTILE_50"
+		reducer = "REDUCE_PERCENTILE_50"
 		break
 	}
 


### PR DESCRIPTION
This uses the Cloud Monitoring package that has support for MQL queries, which will be useful when we start supporting any percentile for latency. The package used here is deprecated, so we should migrate to the new package once support for MQL queries is added to the new Cloud Monitoring package.