### PR TITLE
rollout: Receive a metrics provider in constructor

### DIFF
--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -3,6 +3,7 @@ package rollout
 import (
 	"io/ioutil"
 
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/metrics"
 	runapi "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/run"
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/config"
 	"github.com/pkg/errors"
@@ -19,13 +20,14 @@ type ServiceRecord struct {
 
 // Rollout is the rollout manager.
 type Rollout struct {
-	runClient   runapi.Client
-	service     *run.Service
-	project     string
-	serviceName string
-	region      string
-	log         *logrus.Entry
-	strategy    *config.Strategy
+	runClient       runapi.Client
+	metricsProvider metrics.Metrics
+	service         *run.Service
+	project         string
+	serviceName     string
+	region          string
+	log             *logrus.Entry
+	strategy        *config.Strategy
 
 	// Used to determine if candidate should become stable during update.
 	promoteToStable bool
@@ -39,18 +41,19 @@ const (
 )
 
 // New returns a new rollout manager.
-func New(client runapi.Client, svcRecord *ServiceRecord, strategy *config.Strategy) *Rollout {
+func New(client runapi.Client, metricsProvider metrics.Metrics, svcRecord *ServiceRecord, strategy *config.Strategy) *Rollout {
 	logger := logrus.New()
 	logger.SetOutput(ioutil.Discard)
 
 	return &Rollout{
-		runClient:   client,
-		service:     svcRecord.Service,
-		serviceName: svcRecord.Metadata.Name,
-		project:     svcRecord.Project,
-		region:      svcRecord.Region,
-		strategy:    strategy,
-		log:         logger.WithField("project", svcRecord.Project),
+		runClient:       client,
+		metricsProvider: metricsProvider,
+		service:         svcRecord.Service,
+		serviceName:     svcRecord.Metadata.Name,
+		project:         svcRecord.Project,
+		region:          svcRecord.Region,
+		strategy:        strategy,
+		log:             logger.WithField("project", svcRecord.Project),
 	}
 }
 

--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -23,11 +23,11 @@ type Rollout struct {
 	runClient       runapi.Client
 	metricsProvider metrics.Metrics
 	service         *run.Service
-	project         string
 	serviceName     string
+	project         string
 	region          string
-	log             *logrus.Entry
 	strategy        *config.Strategy
+	log             *logrus.Entry
 
 	// Used to determine if candidate should become stable during update.
 	promoteToStable bool

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/run/mock"
+	metricsMocker "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/metrics/mock"
+	runMocker "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/run/mock"
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/config"
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/rollout"
 	"github.com/google/go-cmp/cmp"
@@ -35,7 +36,8 @@ func generateService(opts *ServiceOpts) *run.Service {
 }
 
 func TestUpdateService(t *testing.T) {
-	runclient := &mock.RunAPI{}
+	runclient := &runMocker.RunAPI{}
+	metricsMock := &metricsMocker.Metrics{}
 	strategy := &config.Strategy{
 		Steps: []int64{10, 40, 70},
 	}
@@ -179,7 +181,7 @@ func TestUpdateService(t *testing.T) {
 		svc := generateService(opts)
 		svcRecord := &rollout.ServiceRecord{Service: svc}
 
-		r := rollout.New(runclient, svcRecord, strategy)
+		r := rollout.New(runclient, metricsMock, svcRecord, strategy)
 
 		t.Run(test.name, func(t *testing.T) {
 			svc, err := r.UpdateService(svc)
@@ -197,7 +199,8 @@ func TestUpdateService(t *testing.T) {
 }
 
 func TestSplitTraffic(t *testing.T) {
-	runclient := &mock.RunAPI{}
+	runclient := &runMocker.RunAPI{}
+	metricsMock := &metricsMocker.Metrics{}
 	strategy := &config.Strategy{
 		Steps: []int64{5, 30, 60},
 	}
@@ -316,7 +319,7 @@ func TestSplitTraffic(t *testing.T) {
 		svc := generateService(opts)
 		svcRecord := &rollout.ServiceRecord{Service: svc}
 
-		r := rollout.New(runclient, svcRecord, strategy)
+		r := rollout.New(runclient, metricsMock, svcRecord, strategy)
 
 		t.Run(test.name, func(t *testing.T) {
 			svc = r.SplitTraffic(svc, test.stable, test.candidate)


### PR DESCRIPTION
This adds a dependency on a metrics provider for the rollout package. This provider will be used when retrieving the candidate's health.
