### PR TITLE
util: Defend against panic when logger is nil

### DIFF
--- a/internal/util/context.go
+++ b/internal/util/context.go
@@ -19,10 +19,10 @@ func ContextWithLogger(ctx context.Context, logger *logrus.Entry) context.Contex
 
 // LoggerFromContext returns the logger from the context.
 func LoggerFromContext(ctx context.Context) *logrus.Entry {
-	logger := ctx.Value(loggerKey).(*logrus.Entry)
+	logger := ctx.Value(loggerKey)
 	if logger == nil {
 		logger = logrus.NewEntry(logrus.New())
 	}
 
-	return logger
+	return logger.(*logrus.Entry)
 }

--- a/internal/util/context.go
+++ b/internal/util/context.go
@@ -20,14 +20,9 @@ func ContextWithLogger(ctx context.Context, logger *logrus.Entry) context.Contex
 // LoggerFromContext returns the logger from the context.
 func LoggerFromContext(ctx context.Context) *logrus.Entry {
 	value := ctx.Value(loggerKey)
-	if value == nil {
-		logrus.Warnf("nil logger in context, creating a new one")
-		return logrus.NewEntry(logrus.New())
-	}
-
 	logger, ok := value.(*logrus.Entry)
 	if !ok {
-		logrus.Warnf("received wrong type of logger (%T)", logger)
+		logrus.Warnf("received wrong type of logger (%T)", value)
 		logger = logrus.NewEntry(logrus.New())
 	}
 

--- a/internal/util/context.go
+++ b/internal/util/context.go
@@ -19,10 +19,17 @@ func ContextWithLogger(ctx context.Context, logger *logrus.Entry) context.Contex
 
 // LoggerFromContext returns the logger from the context.
 func LoggerFromContext(ctx context.Context) *logrus.Entry {
-	logger := ctx.Value(loggerKey)
-	if logger == nil {
+	value := ctx.Value(loggerKey)
+	if value == nil {
+		logrus.Warnf("nil logger in context, creating a new one")
+		return logrus.NewEntry(logrus.New())
+	}
+
+	logger, ok := value.(*logrus.Entry)
+	if !ok {
+		logrus.Warnf("received wrong type of logger (%T)", logger)
 		logger = logrus.NewEntry(logrus.New())
 	}
 
-	return logger.(*logrus.Entry)
+	return logger
 }

--- a/internal/util/context_test.go
+++ b/internal/util/context_test.go
@@ -1,0 +1,42 @@
+package util_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/util"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoggerFromContext(t *testing.T) {
+	tests := []struct {
+		name   string
+		logger *logrus.Logger
+		level  logrus.Level
+	}{
+		{
+			name:   "valid logger",
+			logger: logrus.New(),
+			level:  logrus.DebugLevel,
+		},
+		{
+			name:   "nil logger",
+			logger: nil,
+			level:  logrus.InfoLevel,
+		},
+	}
+
+	for _, test := range tests {
+		var lg *logrus.Entry
+		ctx := context.TODO()
+		if test.logger != nil {
+			test.logger.SetLevel(test.level)
+			lg = logrus.NewEntry(test.logger)
+			ctx = util.ContextWithLogger(ctx, lg)
+		}
+
+		returnedLg := util.LoggerFromContext(ctx).Logger
+		assert.Equal(t, test.level, returnedLg.Level)
+	}
+}


### PR DESCRIPTION
In a previous commit, a nil logger was supposed to be handled. However, the order of the check was reverted. This fixes this issue and handle cases in which the context does not have a logger value.