### PR TITLE
metrics: Remove the Query interface

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -171,7 +171,7 @@ func handleRollout(ctx context.Context, logger *logrus.Logger, service *rollout.
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize Cloud Run API client")
 	}
-	metricsProvider, err := stackdriver.NewProvider(ctx, flProject)
+	metricsProvider, err := stackdriver.NewProvider(ctx, service.Project, service.Region, service.Metadata.Name)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize metrics provider")
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -23,6 +23,8 @@ const (
 type Provider interface {
 	// Sets the candidate revision name for which the provider should get
 	// metrics.
+	// TODO: Consider removing this method and making revisionName part of other
+	// method signatures.
 	SetCandidateRevision(revisionName string)
 
 	// Returns the number of requests for the given offset and query.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -7,34 +7,33 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Query is the filter used to retrieve metrics data.
-type Query interface {
-	Query() string
-}
-
 // AlignReduce is the type to enumerate allowed combinations of per series
 // aligner and cross series reducer.
 type AlignReduce int32
 
 // Series aligner and cross series reducer types (for latency).
 const (
-	Align99Reduce99 AlignReduce = 1
-	Align95Reduce95             = 2
-	Align50Reduce50             = 3
+	Align99Reduce99 AlignReduce = iota + 1
+	Align95Reduce95
+	Align50Reduce50
 )
 
 // Provider represents a metrics Provider such as Stackdriver.
 type Provider interface {
+	// Sets the candidate revision name for which the provider should get
+	// metrics.
+	SetCandidateRevision(revisionName string)
+
 	// Returns the number of requests for the given offset and query.
-	RequestCount(ctx context.Context, query Query, offset time.Duration) (int64, error)
+	RequestCount(ctx context.Context, offset time.Duration) (int64, error)
 
 	// Returns the request latency after applying the specified series aligner
 	// and cross series reducer. The result is in milliseconds.
-	Latency(ctx context.Context, query Query, offset time.Duration, alignReduceType AlignReduce) (float64, error)
+	Latency(ctx context.Context, offset time.Duration, alignReduceType AlignReduce) (float64, error)
 
 	// Gets all the server responses and calculates the error rate by performing
 	// the operation (5xx responses / all responses).
-	ErrorRate(ctx context.Context, query Query, offset time.Duration) (float64, error)
+	ErrorRate(ctx context.Context, offset time.Duration) (float64, error)
 }
 
 // PercentileToAlignReduce takes a percentile value maps it to a AlignReduce

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -13,7 +13,8 @@ type AlignReduce int32
 
 // Series aligner and cross series reducer types (for latency).
 const (
-	Align99Reduce99 AlignReduce = iota + 1
+	Unknown AlignReduce = iota
+	Align99Reduce99
 	Align95Reduce95
 	Align50Reduce50
 )

--- a/internal/metrics/mock/metrics.go
+++ b/internal/metrics/mock/metrics.go
@@ -9,35 +9,46 @@ import (
 
 // Metrics is a mock implementation of metrics.Metrics.
 type Metrics struct {
-	RequestCountFn      func(ctx context.Context, query metrics.Query, offset time.Duration) (int64, error)
+	SetCandidateRevisionFn      func(revisionName string)
+	SetCandidateRevisionInvoked bool
+
+	RequestCountFn      func(ctx context.Context, offset time.Duration) (int64, error)
 	RequestCountInvoked bool
 
-	LatencyFn      func(ctx context.Context, query metrics.Query, offset time.Duration, alignReduceType metrics.AlignReduce) (float64, error)
+	LatencyFn      func(ctx context.Context, offset time.Duration, alignReduceType metrics.AlignReduce) (float64, error)
 	LatencyInvoked bool
 
-	ErrorRateFn      func(ctx context.Context, query metrics.Query, offset time.Duration) (float64, error)
+	ErrorRateFn      func(ctx context.Context, offset time.Duration) (float64, error)
 	ErrorRateInvoked bool
 }
 
 // Query is a mock implementation of metrics.Query.
 type Query struct{}
 
-// RequestCount invokes the mock implementation and marks the function as invoked.
-func (m *Metrics) RequestCount(ctx context.Context, query metrics.Query, offset time.Duration) (int64, error) {
+// SetCandidateRevision invokes the mock implementation and marks the function
+// as invoked.
+func (m *Metrics) SetCandidateRevision(revisionName string) {
+	m.SetCandidateRevisionInvoked = true
+	m.SetCandidateRevisionFn(revisionName)
+}
+
+// RequestCount invokes the mock implementation and marks the function as
+// invoked.
+func (m *Metrics) RequestCount(ctx context.Context, offset time.Duration) (int64, error) {
 	m.RequestCountInvoked = true
-	return m.RequestCountFn(ctx, query, offset)
+	return m.RequestCountFn(ctx, offset)
 }
 
 // Latency invokes the mock implementation and marks the function as invoked.
-func (m *Metrics) Latency(ctx context.Context, query metrics.Query, offset time.Duration, alignReduceType metrics.AlignReduce) (float64, error) {
+func (m *Metrics) Latency(ctx context.Context, offset time.Duration, alignReduceType metrics.AlignReduce) (float64, error) {
 	m.LatencyInvoked = true
-	return m.LatencyFn(ctx, query, offset, alignReduceType)
+	return m.LatencyFn(ctx, offset, alignReduceType)
 }
 
 // ErrorRate invokes the mock implementation and marks the function as invoked.
-func (m *Metrics) ErrorRate(ctx context.Context, query metrics.Query, offset time.Duration) (float64, error) {
+func (m *Metrics) ErrorRate(ctx context.Context, offset time.Duration) (float64, error) {
 	m.ErrorRateInvoked = true
-	return m.ErrorRateFn(ctx, query, offset)
+	return m.ErrorRateFn(ctx, offset)
 }
 
 // Query returns an empty string to comply with the interface.

--- a/internal/stackdriver/stackdriver.go
+++ b/internal/stackdriver/stackdriver.go
@@ -47,14 +47,13 @@ func NewProvider(ctx context.Context, project string, region string, serviceName
 	}, nil
 }
 
-// SetCandidateRevision sets the candidate revision name for which the provide
-// should get metrics for.
+// SetCandidateRevision sets the candidate revision name for which the provider
+// should get metrics.
 func (p *Provider) SetCandidateRevision(revisionName string) {
 	p.query = p.query.addFilter("resource.labels.revision_name", revisionName)
 }
 
-// RequestCount count returns the number of requests for the given offset and
-// query.
+// RequestCount count returns the number of requests for the given offset.
 func (p *Provider) RequestCount(ctx context.Context, offset time.Duration) (int64, error) {
 	query := p.addFilter("metric.type", requestCount)
 	endTime := time.Now()
@@ -96,7 +95,7 @@ func (p *Provider) RequestCount(ctx context.Context, offset time.Duration) (int6
 	return *(series.Points[0].Value.Int64Value), nil
 }
 
-// Latency returns the latency for the resource matching the filter.
+// Latency returns the latency for the resource for the given offset.
 func (p *Provider) Latency(ctx context.Context, offset time.Duration, alignReduceType metrics.AlignReduce) (float64, error) {
 	query := p.query.addFilter("metric.type", requestLatencies)
 	endTime := time.Now()
@@ -141,7 +140,7 @@ func (p *Provider) Latency(ctx context.Context, offset time.Duration, alignReduc
 	return *(series.Points[0].Value.DoubleValue), nil
 }
 
-// ErrorRate returns the rate of 5xx errors for the resource matching the filter.
+// ErrorRate returns the rate of 5xx errors for the resource in the given offset.
 func (p *Provider) ErrorRate(ctx context.Context, offset time.Duration) (float64, error) {
 	query := p.query.addFilter("metric.type", requestCount)
 	endTime := time.Now()

--- a/internal/stackdriver/stackdriver_internal_test.go
+++ b/internal/stackdriver/stackdriver_internal_test.go
@@ -1,0 +1,39 @@
+package stackdriver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		keys     []string
+		values   []string
+		expected string
+	}{
+		{
+			name:     "single filter",
+			keys:     []string{"key1"},
+			values:   []string{"value1"},
+			expected: "key1=\"value1\"",
+		},
+		{
+			name:     "multiple filters",
+			keys:     []string{"key1", "key2", "key3"},
+			values:   []string{"value1", "value2", "value3"},
+			expected: "key1=\"value1\" AND key2=\"value2\" AND key3=\"value3\"",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var q query
+			for i, key := range test.keys {
+				q = q.addFilter(key, test.values[i])
+			}
+			assert.Equal(t, test.expected, string(q))
+		})
+	}
+}

--- a/internal/stackdriver/stackdriver_test.go
+++ b/internal/stackdriver/stackdriver_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAddFilter(t *testing.T) {
+func TestQuery_addFilter(t *testing.T) {
 	tests := []struct {
 		name     string
 		keys     []string
@@ -17,13 +17,13 @@ func TestAddFilter(t *testing.T) {
 			name:     "single filter",
 			keys:     []string{"key1"},
 			values:   []string{"value1"},
-			expected: "key1=\"value1\"",
+			expected: `key1="value1"`,
 		},
 		{
 			name:     "multiple filters",
 			keys:     []string{"key1", "key2", "key3"},
 			values:   []string{"value1", "value2", "value3"},
-			expected: "key1=\"value1\" AND key2=\"value2\" AND key3=\"value3\"",
+			expected: `key1="value1" AND key2="value2" AND key3="value3"`,
 		},
 	}
 


### PR DESCRIPTION
The Query interface was always passed through the chain without changes to it, which makes it very hard to deduct its use. This removes the interface altogether and keep the filters as parameters of the provider constructor.

A new method SetCandidateRevision was added to the Provider interface since the candidate revision can only be determined during the rollout process. Furthermore, it looks like knowing the queried resource (i.e. the candidate revision) is necessary for any metrics provider.
