### PR TITLE
health: Separate metrics collection from diagnosis

### DIFF
--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -92,17 +92,17 @@ func CollectMetrics(ctx context.Context, provider metrics.Provider, offset time.
 	if len(healthCriteria) == 0 {
 		return nil, errors.New("health criteria must be specified")
 	}
-	var results []float64
+	var metricsValues []float64
 	for _, criteria := range healthCriteria {
-		var value float64
+		var metricsValue float64
 		var err error
 
 		switch criteria.Type {
 		case config.LatencyMetricsCheck:
-			value, err = latency(ctx, provider, offset, criteria.Percentile)
+			metricsValue, err = latency(ctx, provider, offset, criteria.Percentile)
 			break
 		case config.ErrorRateMetricsCheck:
-			value, err = errorRatePercent(ctx, provider, offset)
+			metricsValue, err = errorRatePercent(ctx, provider, offset)
 			break
 		default:
 			return nil, errors.Errorf("unimplemented metrics %q", criteria.Type)
@@ -111,10 +111,10 @@ func CollectMetrics(ctx context.Context, provider metrics.Provider, offset time.
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to obtain metrics %q", criteria.Type)
 		}
-		results = append(results, value)
+		metricsValues = append(metricsValues, metricsValue)
 	}
 
-	return results, nil
+	return metricsValues, nil
 }
 
 // isCriteriaMet concludes if metrics criteria was met.

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -99,7 +99,6 @@ func TestDiagnosis(t *testing.T) {
 					},
 				},
 			},
-			shouldErr: true,
 		},
 		{
 			name:      "should err, empty health criteria",

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -26,8 +26,22 @@ func TestDiagnosis(t *testing.T) {
 				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
 				{Type: config.ErrorRateMetricsCheck, Threshold: 5},
 			},
-			results:  []float64{500.0, 1.0},
-			expected: health.Healthy,
+			results: []float64{500.0, 1.0},
+			expected: health.Diagnosis{
+				OverallResult: health.Healthy,
+				CheckResults: []health.CheckResult{
+					{
+						Threshold:     750.0,
+						ActualValue:   500.0,
+						IsCriteriaMet: true,
+					},
+					{
+						Threshold:     5.0,
+						ActualValue:   1.0,
+						IsCriteriaMet: true,
+					},
+				},
+			},
 		},
 		{
 			name: "barely healthy revision",
@@ -35,24 +49,56 @@ func TestDiagnosis(t *testing.T) {
 				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 500},
 				{Type: config.ErrorRateMetricsCheck, Threshold: 1},
 			},
-			results:  []float64{500.0, 1.0},
-			expected: health.Healthy,
+			results: []float64{500.0, 1.0},
+			expected: health.Diagnosis{
+				OverallResult: health.Healthy,
+				CheckResults: []health.CheckResult{
+					{
+						Threshold:     500.0,
+						ActualValue:   500.0,
+						IsCriteriaMet: true,
+					},
+					{
+						Threshold:     1.0,
+						ActualValue:   1.0,
+						IsCriteriaMet: true,
+					},
+				},
+			},
 		},
 		{
 			name: "unhealthy revision, miss latency",
 			healthCriteria: []config.Metric{
 				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 499},
 			},
-			results:  []float64{500.0},
-			expected: health.Unhealthy,
+			results: []float64{500.0},
+			expected: health.Diagnosis{
+				OverallResult: health.Unhealthy,
+				CheckResults: []health.CheckResult{
+					{
+						Threshold:     499.0,
+						ActualValue:   500.0,
+						IsCriteriaMet: false,
+					},
+				},
+			},
 		},
 		{
 			name: "unhealthy revision, miss error rate",
 			healthCriteria: []config.Metric{
 				{Type: config.ErrorRateMetricsCheck, Threshold: 0.95},
 			},
-			results:  []float64{1.0},
-			expected: health.Unhealthy,
+			results: []float64{1.0},
+			expected: health.Diagnosis{
+				OverallResult: health.Unhealthy,
+				CheckResults: []health.CheckResult{
+					{
+						Threshold:     0.95,
+						ActualValue:   1.0,
+						IsCriteriaMet: false,
+					},
+				},
+			},
 		},
 		{
 			name: "should err, different sizes for criteria and results",

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -99,6 +99,11 @@ func TestDiagnosis(t *testing.T) {
 					},
 				},
 			},
+			shouldErr: true,
+		},
+		{
+			name:      "should err, empty health criteria",
+			shouldErr: true,
 		},
 		{
 			name: "should err, different sizes for criteria and results",


### PR DESCRIPTION
This separates the collection of metrics values from the actual diagnosis of the health of the revision. It closes #30 