### PR TITLE
rollout: Add methods to include client and context

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -175,7 +175,7 @@ func handleRollout(ctx context.Context, logger *logrus.Logger, service *rollout.
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize metrics provider")
 	}
-	roll := rollout.New(client, metricsProvider, service, strategy).WithLogger(lg.Logger)
+	roll := rollout.New(metricsProvider, service, strategy).WithClient(client).WithContext(ctx).WithLogger(lg.Logger)
 
 	changed, err := roll.Rollout()
 	if err != nil {

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -175,7 +175,7 @@ func handleRollout(ctx context.Context, logger *logrus.Logger, service *rollout.
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize metrics provider")
 	}
-	roll := rollout.New(metricsProvider, service, strategy).WithClient(client).WithContext(ctx).WithLogger(lg.Logger)
+	roll := rollout.New(ctx, metricsProvider, service, strategy).WithClient(client).WithLogger(lg.Logger)
 
 	changed, err := roll.Rollout()
 	if err != nil {

--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -54,6 +54,7 @@ func New(metricsProvider metrics.Provider, svcRecord *ServiceRecord, strategy *c
 		project:         svcRecord.Project,
 		region:          svcRecord.Region,
 		strategy:        strategy,
+		ctx:             context.TODO(),
 		log:             logrus.NewEntry(logrus.New()),
 	}
 }

--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -21,6 +21,7 @@ type ServiceRecord struct {
 
 // Rollout is the rollout manager.
 type Rollout struct {
+	ctx             context.Context
 	metricsProvider metrics.Provider
 	service         *run.Service
 	serviceName     string
@@ -28,7 +29,6 @@ type Rollout struct {
 	region          string
 	strategy        *config.Strategy
 	runClient       runapi.Client
-	ctx             context.Context
 	log             *logrus.Entry
 
 	// Used to determine if candidate should become stable during update.
@@ -43,18 +43,18 @@ const (
 )
 
 // New returns a new rollout manager.
-func New(metricsProvider metrics.Provider, svcRecord *ServiceRecord, strategy *config.Strategy) *Rollout {
+func New(ctx context.Context, metricsProvider metrics.Provider, svcRecord *ServiceRecord, strategy *config.Strategy) *Rollout {
 	logger := logrus.New()
 	logger.SetOutput(ioutil.Discard)
 
 	return &Rollout{
+		ctx:             ctx,
 		metricsProvider: metricsProvider,
 		service:         svcRecord.Service,
 		serviceName:     svcRecord.Metadata.Name,
 		project:         svcRecord.Project,
 		region:          svcRecord.Region,
 		strategy:        strategy,
-		ctx:             context.TODO(),
 		log:             logrus.NewEntry(logrus.New()),
 	}
 }
@@ -62,12 +62,6 @@ func New(metricsProvider metrics.Provider, svcRecord *ServiceRecord, strategy *c
 // WithClient updates the client in the rollout instance.
 func (r *Rollout) WithClient(client runapi.Client) *Rollout {
 	r.runClient = client
-	return r
-}
-
-// WithContext updates the context in the rollout instance.
-func (r *Rollout) WithContext(ctx context.Context) *Rollout {
-	r.ctx = ctx
 	return r
 }
 

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -181,7 +181,7 @@ func TestUpdateService(t *testing.T) {
 		svc := generateService(opts)
 		svcRecord := &rollout.ServiceRecord{Service: svc}
 
-		r := rollout.New(runclient, metricsMock, svcRecord, strategy)
+		r := rollout.New(metricsMock, svcRecord, strategy).WithClient(runclient)
 
 		t.Run(test.name, func(t *testing.T) {
 			svc, err := r.UpdateService(svc)
@@ -319,7 +319,7 @@ func TestSplitTraffic(t *testing.T) {
 		svc := generateService(opts)
 		svcRecord := &rollout.ServiceRecord{Service: svc}
 
-		r := rollout.New(runclient, metricsMock, svcRecord, strategy)
+		r := rollout.New(metricsMock, svcRecord, strategy).WithClient(runclient)
 
 		t.Run(test.name, func(t *testing.T) {
 			svc = r.SplitTraffic(svc, test.stable, test.candidate)

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -1,6 +1,7 @@
 package rollout_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -181,7 +182,7 @@ func TestUpdateService(t *testing.T) {
 		svc := generateService(opts)
 		svcRecord := &rollout.ServiceRecord{Service: svc}
 
-		r := rollout.New(metricsMock, svcRecord, strategy).WithClient(runclient)
+		r := rollout.New(context.TODO(), metricsMock, svcRecord, strategy).WithClient(runclient)
 
 		t.Run(test.name, func(t *testing.T) {
 			svc, err := r.UpdateService(svc)
@@ -319,7 +320,7 @@ func TestSplitTraffic(t *testing.T) {
 		svc := generateService(opts)
 		svcRecord := &rollout.ServiceRecord{Service: svc}
 
-		r := rollout.New(metricsMock, svcRecord, strategy).WithClient(runclient)
+		r := rollout.New(context.TODO(), metricsMock, svcRecord, strategy).WithClient(runclient)
 
 		t.Run(test.name, func(t *testing.T) {
 			svc = r.SplitTraffic(svc, test.stable, test.candidate)


### PR DESCRIPTION
This adds two methods that allows the update of the client and context used for rollouts. The context would become useful when we have to pass a context to the health package.