### PR TITLE
rollout: Rollback when candidate is unhealthy

### DIFF
--- a/pkg/rollout/revision.go
+++ b/pkg/rollout/revision.go
@@ -1,8 +1,6 @@
 package rollout
 
 import (
-	"log"
-
 	"google.golang.org/api/run/v1"
 )
 
@@ -87,7 +85,6 @@ func findRevisionWithTag(svc *run.Service, tag string) string {
 // about it (it has 0 traffic), so the rollout process should add some initial
 // to the new revision.
 func isNewCandidate(svc *run.Service, currentCandidate string) bool {
-	log.Println(currentCandidate)
 	lastFailedCandidate := svc.Metadata.Annotations[LastFailedCandidateRevisionAnnotation]
 	for _, target := range svc.Spec.Traffic {
 		if target.RevisionName == currentCandidate {

--- a/pkg/rollout/revision.go
+++ b/pkg/rollout/revision.go
@@ -85,14 +85,14 @@ func findRevisionWithTag(svc *run.Service, tag string) string {
 // about it (it has 0 traffic), so the rollout process should add some initial
 // traffic to the new revision.
 func isNewCandidate(svc *run.Service, currentCandidate string) bool {
-	lastFailedCandidate := svc.Metadata.Annotations[LastFailedCandidateRevisionAnnotation]
 	for _, target := range svc.Spec.Traffic {
 		if target.RevisionName == currentCandidate {
-			return currentCandidate != lastFailedCandidate && target.Percent == 0
+			return target.Percent == 0
 		}
 	}
 
-	// The current candidate was not part of the service traffic config because
-	// it has no traffic.
+	// Cloud Run (often) removes traffic targets for revisions that have no
+	// traffic. If the candidate was not found in the traffic configuration, it
+	// means the revision is a new candidate.
 	return true
 }

--- a/pkg/rollout/revision.go
+++ b/pkg/rollout/revision.go
@@ -91,7 +91,6 @@ func isNewCandidate(svc *run.Service, currentCandidate string) bool {
 	lastFailedCandidate := svc.Metadata.Annotations[LastFailedCandidateRevisionAnnotation]
 	for _, target := range svc.Spec.Traffic {
 		if target.RevisionName == currentCandidate {
-			log.Println("here")
 			return currentCandidate != lastFailedCandidate && target.Percent == 0
 		}
 	}

--- a/pkg/rollout/revision.go
+++ b/pkg/rollout/revision.go
@@ -83,7 +83,7 @@ func findRevisionWithTag(svc *run.Service, tag string) string {
 //
 // Knowing that a candidate is new is helpful since metrics cannot be obtained
 // about it (it has 0 traffic), so the rollout process should add some initial
-// to the new revision.
+// traffic to the new revision.
 func isNewCandidate(svc *run.Service, currentCandidate string) bool {
 	lastFailedCandidate := svc.Metadata.Annotations[LastFailedCandidateRevisionAnnotation]
 	for _, target := range svc.Spec.Traffic {

--- a/pkg/rollout/revision_test.go
+++ b/pkg/rollout/revision_test.go
@@ -76,13 +76,17 @@ func TestDetectStableRevisionName(t *testing.T) {
 func TestDetectCandidateRevisionName(t *testing.T) {
 	var tests = []struct {
 		name           string
+		annotations    map[string]string
+		traffic        []*run.TrafficTarget
 		latestReady    string
 		stableRevision string
 		expected       string
+		newCandidate   bool
 	}{
 		// Latest revision is the same as the stable one.
 		{
 			name:           "same latest and stable revisions",
+			annotations:    map[string]string{},
 			latestReady:    "test-001",
 			stableRevision: "test-001",
 			expected:       "",
@@ -90,19 +94,60 @@ func TestDetectCandidateRevisionName(t *testing.T) {
 		// Latest revision is not the same as the stable one.
 		{
 			name:           "different latest and stable revisions",
+			annotations:    map[string]string{},
 			latestReady:    "test-002",
 			stableRevision: "test-001",
 			expected:       "test-002",
+			newCandidate:   true,
+		},
+		// Latest revision is not the same as the stable one, but latest was unhealthy.
+		{
+			name: "latest revision was previously unhealthy",
+			annotations: map[string]string{
+				rollout.LastFailedCandidateRevisionAnnotation: "test-002",
+			},
+			latestReady:    "test-002",
+			stableRevision: "test-001",
+			expected:       "",
+		},
+		// Same candidate as previous process.
+		{
+			name:        "same candidate",
+			annotations: map[string]string{},
+			traffic: []*run.TrafficTarget{
+				{RevisionName: "test-002", Percent: 50, Tag: rollout.CandidateTag},
+			},
+			latestReady:    "test-002",
+			stableRevision: "test-001",
+			expected:       "test-002",
+			newCandidate:   false,
+		},
+		// Different candidate from previous process.
+		{
+			name:        "different candidate",
+			annotations: map[string]string{},
+			traffic: []*run.TrafficTarget{
+				{RevisionName: "test-002", Percent: 50, Tag: rollout.CandidateTag},
+			},
+			latestReady:    "test-003",
+			stableRevision: "test-001",
+			expected:       "test-003",
+			newCandidate:   true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			opts := &ServiceOpts{LatestReadyRevision: test.latestReady}
+			opts := &ServiceOpts{
+				Traffic:             test.traffic,
+				Annotations:         test.annotations,
+				LatestReadyRevision: test.latestReady,
+			}
 			svc := generateService(opts)
-			candidate := rollout.DetectCandidateRevisionName(svc, test.stableRevision)
+			candidate, isNew := rollout.DetectCandidateRevisionName(svc, test.stableRevision)
 
 			assert.Equal(t, test.expected, candidate)
+			assert.Equal(t, test.newCandidate, isNew)
 		})
 	}
 }

--- a/pkg/rollout/revision_test.go
+++ b/pkg/rollout/revision_test.go
@@ -81,12 +81,10 @@ func TestDetectCandidateRevisionName(t *testing.T) {
 		latestReady    string
 		stableRevision string
 		expected       string
-		newCandidate   bool
 	}{
 		// Latest revision is the same as the stable one.
 		{
 			name:           "same latest and stable revisions",
-			annotations:    map[string]string{},
 			latestReady:    "test-001",
 			stableRevision: "test-001",
 			expected:       "",
@@ -94,11 +92,9 @@ func TestDetectCandidateRevisionName(t *testing.T) {
 		// Latest revision is not the same as the stable one.
 		{
 			name:           "different latest and stable revisions",
-			annotations:    map[string]string{},
 			latestReady:    "test-002",
 			stableRevision: "test-001",
 			expected:       "test-002",
-			newCandidate:   true,
 		},
 		// Latest revision is not the same as the stable one, but latest was unhealthy.
 		{
@@ -110,30 +106,6 @@ func TestDetectCandidateRevisionName(t *testing.T) {
 			stableRevision: "test-001",
 			expected:       "",
 		},
-		// Same candidate as previous process.
-		{
-			name:        "same candidate",
-			annotations: map[string]string{},
-			traffic: []*run.TrafficTarget{
-				{RevisionName: "test-002", Percent: 50, Tag: rollout.CandidateTag},
-			},
-			latestReady:    "test-002",
-			stableRevision: "test-001",
-			expected:       "test-002",
-			newCandidate:   false,
-		},
-		// Different candidate from previous process.
-		{
-			name:        "different candidate",
-			annotations: map[string]string{},
-			traffic: []*run.TrafficTarget{
-				{RevisionName: "test-002", Percent: 50, Tag: rollout.CandidateTag},
-			},
-			latestReady:    "test-003",
-			stableRevision: "test-001",
-			expected:       "test-003",
-			newCandidate:   true,
-		},
 	}
 
 	for _, test := range tests {
@@ -144,10 +116,9 @@ func TestDetectCandidateRevisionName(t *testing.T) {
 				LatestReadyRevision: test.latestReady,
 			}
 			svc := generateService(opts)
-			candidate, isNew := rollout.DetectCandidateRevisionName(svc, test.stableRevision)
+			candidate := rollout.DetectCandidateRevisionName(svc, test.stableRevision)
 
 			assert.Equal(t, test.expected, candidate)
-			assert.Equal(t, test.newCandidate, isNew)
 		})
 	}
 }

--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -175,8 +175,8 @@ func (r *Rollout) PrepareRollForward(svc *run.Service, stable, candidate string)
 	traffic = append(traffic, inheritRevisionTags(svc)...)
 
 	if !r.promoteToStable {
-		r.log.Infof("will assign %d%% of the traffic to stable revision %s", stablePercent, stable)
-		r.log.Infof("will assign %d%% of the traffic to candidate revision %s", candidateTraffic.Percent, candidate)
+		r.log.Infof("will assign %d%% of the traffic to stable revision", stablePercent)
+		r.log.Infof("will assign %d%% of the traffic to candidate revision", candidateTraffic.Percent)
 	} else {
 		r.log.Infof("will make revision %s stable", candidate)
 	}

--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -14,15 +14,6 @@ import (
 	"google.golang.org/api/run/v1"
 )
 
-type nextAction int
-
-const (
-	unknown nextAction = iota
-	nothing
-	rollforward
-	rollback
-)
-
 // ServiceRecord holds a service object and information about it.
 type ServiceRecord struct {
 	*run.Service

--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -310,6 +310,7 @@ func (r *Rollout) diagnoseCandidate(candidate string, healthCriteria []config.Me
 	healthCheckOffset := time.Duration(r.strategy.Interval) * time.Second
 	r.log.Debug("collecting metrics from API")
 	ctx := util.ContextWithLogger(r.ctx, r.log)
+	r.metricsProvider.SetCandidateRevision(candidate)
 	metricsValues, err := health.CollectMetrics(ctx, r.metricsProvider, healthCheckOffset, healthCriteria)
 	if err != nil {
 		return d, errors.Wrap(err, "failed to collect metrics")

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -48,6 +48,7 @@ func TestUpdateService(t *testing.T) {
 	metricsMock.ErrorRateFn = func(ctx context.Context, offset time.Duration) (float64, error) {
 		return 0.01, nil
 	}
+	metricsMock.SetCandidateRevisionFn = func(revisionName string) {}
 	strategy := &config.Strategy{
 		Steps: []int64{10, 40, 70},
 	}

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -261,7 +261,7 @@ func TestUpdateService(t *testing.T) {
 	}
 }
 
-func TestRollForward(t *testing.T) {
+func TestPrepareRollForward(t *testing.T) {
 	runclient := &runMocker.RunAPI{}
 	metricsMock := &metricsMocker.Metrics{}
 	strategy := &config.Strategy{
@@ -385,13 +385,13 @@ func TestRollForward(t *testing.T) {
 		r := rollout.New(context.TODO(), metricsMock, svcRecord, strategy).WithClient(runclient)
 
 		t.Run(test.name, func(t *testing.T) {
-			svc = r.RollForward(svc, test.stable, test.candidate)
+			svc = r.PrepareRollForward(svc, test.stable, test.candidate)
 			assert.True(t, cmp.Equal(test.expected, svc.Spec.Traffic))
 		})
 	}
 }
 
-func TestRollback(t *testing.T) {
+func TestPrepareRollback(t *testing.T) {
 	metricsMock := &metricsMocker.Metrics{}
 
 	stable := "test-001"
@@ -413,6 +413,6 @@ func TestRollback(t *testing.T) {
 	svcRecord := &rollout.ServiceRecord{Service: svc}
 
 	r := rollout.New(context.TODO(), metricsMock, svcRecord, &config.Strategy{})
-	svc = r.Rollback(svc, stable, candidate)
+	svc = r.PrepareRollback(svc, stable, candidate)
 	assert.Equal(t, expectedTraffic, svc.Spec.Traffic)
 }


### PR DESCRIPTION
This integrates with the health package to diagnose the candidate's health. If it is unhealthy, a rollback is performed.