### PR TITLE
config: Validate metrics criteria configuration

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -132,8 +132,8 @@ func main() {
 	healthCriteria := healthCriteriaFromFlags(flErrorRate, flLatencyP99, flLatencyP95, flLatencyP50)
 	printHealthCriteria(logger, healthCriteria)
 	cfg := config.WithValues([]*config.Target{target}, flSteps, flInterval, healthCriteria)
-	if !cfg.IsValid(flCLI) {
-		logger.Fatalf("invalid rollout configuration")
+	if valid, err := cfg.IsValid(flCLI); !valid {
+		logger.Fatalf("invalid rollout configuration: %v", err)
 	}
 
 	ctx := context.Background()

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -132,7 +132,7 @@ func main() {
 	healthCriteria := healthCriteriaFromFlags(flErrorRate, flLatencyP99, flLatencyP95, flLatencyP50)
 	printHealthCriteria(logger, healthCriteria)
 	cfg := config.WithValues([]*config.Target{target}, flSteps, flInterval, healthCriteria)
-	if valid, err := cfg.IsValid(flCLI); !valid {
+	if err := cfg.Validate(flCLI); err != nil {
 		logger.Fatalf("invalid rollout configuration: %v", err)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -125,13 +125,13 @@ func validateMetrics(metricsCriteria Metric) error {
 }
 
 func validateTargets(targets []*Target) error {
-	for _, target := range targets {
+	for i, target := range targets {
 		if target.Project == "" {
-			return errors.New("project must be specified in target")
+			return errors.Errorf("project must be specified in target at index %d", i)
 		}
 
 		if target.LabelSelector == "" {
-			return errors.New("label must be specified in target")
+			return errors.Errorf("label must be specified in target at index %d", i)
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -9,62 +9,61 @@ import (
 
 func TestIsValid(t *testing.T) {
 	tests := []struct {
-		name     string
-		config   *config.Config
-		cliMode  bool
-		expected bool
+		name      string
+		config    *config.Config
+		cliMode   bool
+		shouldErr bool
 	}{
 		{
 			name: "correct config with label selector",
 			config: config.WithValues([]*config.Target{
 				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
 			}, []int64{5, 30, 60}, 20, nil),
-			expected: true,
 		},
 		{
 			name: "missing project",
 			config: config.WithValues([]*config.Target{
 				config.NewTarget("", []string{"us-east1", "us-west1"}, "team=backend"),
 			}, []int64{5, 30, 60}, 20, nil),
-			expected: false,
+			shouldErr: true,
 		},
 		{
 			name: "missing steps",
 			config: config.WithValues([]*config.Target{
 				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
 			}, []int64{}, 20, nil),
-			cliMode:  true,
-			expected: false,
+			cliMode:   true,
+			shouldErr: true,
 		},
 		{
 			name: "steps not in order",
 			config: config.WithValues([]*config.Target{
 				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
 			}, []int64{30, 30, 60}, 20, nil),
-			cliMode:  true,
-			expected: false,
+			cliMode:   true,
+			shouldErr: true,
 		},
 		{
 			name: "step greater than 100",
 			config: config.WithValues([]*config.Target{
 				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
 			}, []int64{5, 30, 101}, 20, nil),
-			expected: false,
+			shouldErr: true,
 		},
 		{
 			name: "no interval for cli mode",
 			config: config.WithValues([]*config.Target{
 				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
 			}, []int64{5, 30, 60}, 0, nil),
-			cliMode:  true,
-			expected: false,
+			cliMode:   true,
+			shouldErr: true,
 		},
 		{
 			name: "empty label selector",
 			config: config.WithValues([]*config.Target{
 				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, ""),
 			}, []int64{5, 30, 60}, 20, nil),
-			expected: false,
+			shouldErr: true,
 		},
 		{
 			name: "invalid error rate in metrics",
@@ -75,7 +74,7 @@ func TestIsValid(t *testing.T) {
 					{Type: config.ErrorRateMetricsCheck, Threshold: 101},
 				},
 			),
-			expected: false,
+			shouldErr: true,
 		},
 		{
 			name: "invalid latency percentile",
@@ -86,7 +85,7 @@ func TestIsValid(t *testing.T) {
 					{Type: config.LatencyMetricsCheck, Percentile: 98},
 				},
 			),
-			expected: false,
+			shouldErr: true,
 		},
 		{
 			name: "invalid latency value",
@@ -97,14 +96,18 @@ func TestIsValid(t *testing.T) {
 					{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: -1},
 				},
 			),
-			expected: false,
+			shouldErr: true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			isValid, _ := test.config.IsValid(test.cliMode)
-			assert.Equal(t, test.expected, isValid)
+			err := test.config.Validate(test.cliMode)
+			if test.shouldErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This validates that the metrics criteria to err sooner for an invalid value. It also adds an extra return value in `config.IsValid` to specify the problem with the configuration object.