### PR TITLE
config: Add configuration for min request count

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -70,13 +70,14 @@ var (
 	flRegionsString string
 
 	// Rollout strategy-related flags.
-	flSteps       stepFlags
-	flStepsString string
-	flInterval    int64
-	flErrorRate   float64
-	flLatencyP99  float64
-	flLatencyP95  float64
-	flLatencyP50  float64
+	flSteps           stepFlags
+	flStepsString     string
+	flInterval        int64
+	flMinRequestCount uint64
+	flErrorRate       float64
+	flLatencyP99      float64
+	flLatencyP95      float64
+	flLatencyP50      float64
 
 	// Metrics provider flags.
 	flGoogleSheetsID string
@@ -92,6 +93,7 @@ func init() {
 	flag.Var(&flSteps, "step", "a percentage in traffic the candidate should go through")
 	flag.StringVar(&flStepsString, "steps", "5,20,50,80", "define steps in one flag separated by commas (e.g. 5,30,60)")
 	flag.Int64Var(&flInterval, "interval", 0, "the time between each rollout step")
+	flag.Uint64Var(&flMinRequestCount, "min-requests", 0, "expected minimum requests before determining candidate's health")
 	flag.Float64Var(&flErrorRate, "max-error-rate", 1.0, "expected max server error rate (in percent)")
 	flag.Float64Var(&flLatencyP99, "latency-p99", 0, "expected max latency for 99th percentile of requests (set 0 to ignore)")
 	flag.Float64Var(&flLatencyP95, "latency-p95", 0, "expected max latency for 95th percentile of requests (set 0 to ignore)")
@@ -129,7 +131,7 @@ func main() {
 
 	// Configuration.
 	target := config.NewTarget(flProject, flRegions, flLabelSelector)
-	healthCriteria := healthCriteriaFromFlags(flErrorRate, flLatencyP99, flLatencyP95, flLatencyP50)
+	healthCriteria := healthCriteriaFromFlags(flMinRequestCount, flErrorRate, flLatencyP99, flLatencyP95, flLatencyP50)
 	printHealthCriteria(logger, healthCriteria)
 	cfg := config.WithValues([]*config.Target{target}, flSteps, flInterval, healthCriteria)
 	if err := cfg.Validate(flCLI); err != nil {
@@ -240,9 +242,10 @@ func chooseMetricsProvider(ctx context.Context, logger *logrus.Entry, project, r
 
 // healthCriteriaFromFlags checks the metrics-related flags and return an array
 // of config.Metric based on them.
-func healthCriteriaFromFlags(errorRate, latencyP99, latencyP95, latencyP50 float64) []config.Metric {
+func healthCriteriaFromFlags(requestCount uint64, errorRate, latencyP99, latencyP95, latencyP50 float64) []config.Metric {
 	metrics := []config.Metric{
 		{Type: config.ErrorRateMetricsCheck, Threshold: errorRate},
+		{Type: config.RequestCountMetricsCheck, Threshold: float64(requestCount)},
 	}
 
 	if latencyP99 > 0 {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,8 +9,9 @@ type MetricsCheck string
 
 // Supported metrics checks.
 const (
-	LatencyMetricsCheck   MetricsCheck = "request-latency"
-	ErrorRateMetricsCheck MetricsCheck = "error-rate-percent"
+	RequestCountMetricsCheck MetricsCheck = "request-count"
+	LatencyMetricsCheck      MetricsCheck = "request-latency"
+	ErrorRateMetricsCheck    MetricsCheck = "error-rate-percent"
 )
 
 // Target is the configuration to filter services.
@@ -104,9 +105,13 @@ func (config *Config) Validate(cliMode bool) error {
 
 func validateMetrics(metricsCriteria Metric) error {
 	threshold := metricsCriteria.Threshold
+	if threshold < 0 {
+		return errors.Errorf("threshold cannot be negative, criteria %q", metricsCriteria.Type)
+	}
+
 	switch metricsCriteria.Type {
 	case ErrorRateMetricsCheck:
-		if threshold > 100 || threshold < 0 {
+		if threshold > 100 {
 			return errors.Errorf("threshold must be greater than 0 and less than 100 for %q", metricsCriteria.Type)
 		}
 	case LatencyMetricsCheck:
@@ -114,9 +119,8 @@ func validateMetrics(metricsCriteria Metric) error {
 		if percentile != 99 && percentile != 95 && percentile != 50 {
 			return errors.Errorf("invalid percentile for %q", metricsCriteria.Type)
 		}
-		if metricsCriteria.Threshold < 0 {
-			return errors.Errorf("threshold cannot be negative for %q", metricsCriteria.Type)
-		}
+	case RequestCountMetricsCheck:
+		return nil
 	default:
 		return errors.Errorf("invalid metric criteria %q", metricsCriteria.Type)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -66,6 +66,17 @@ func TestIsValid(t *testing.T) {
 			shouldErr: true,
 		},
 		{
+			name: "invalid request count value",
+			config: config.WithValues([]*config.Target{
+				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
+			}, []int64{5, 30, 60}, 20,
+				[]config.Metric{
+					{Type: config.RequestCountMetricsCheck, Threshold: -1},
+				},
+			),
+			shouldErr: true,
+		},
+		{
 			name: "invalid error rate in metrics",
 			config: config.WithValues([]*config.Target{
 				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),


### PR DESCRIPTION
This adds configuration and flag to specify the minimum number of requests needed to diagnose the candidate's health