### PR TITLE
config: Change internal name for metrics criteria

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,8 +38,8 @@ type Metric struct {
 
 // Strategy is the steps and configuration for rollout.
 type Strategy struct {
-	Steps   []int64
-	Metrics []Metric
+	Steps          []int64
+	HealthCriteria []Metric
 
 	// TODO: Give this property a clearer name.
 	Interval int64
@@ -59,9 +59,9 @@ func WithValues(targets []*Target, steps []int64, interval int64, metrics []Metr
 	return &Config{
 		Targets: targets,
 		Strategy: &Strategy{
-			Steps:    steps,
-			Metrics:  metrics,
-			Interval: interval,
+			Steps:          steps,
+			HealthCriteria: metrics,
+			Interval:       interval,
 		},
 	}
 }
@@ -94,7 +94,7 @@ func (config *Config) Validate(cliMode bool) error {
 		previous = step
 	}
 
-	for i, criteria := range config.Strategy.Metrics {
+	for i, criteria := range config.Strategy.HealthCriteria {
 		if err := validateMetrics(criteria); err != nil {
 			return errors.Wrapf(err, "invalid metrics criteria at index %d", i)
 		}

--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -119,7 +119,7 @@ func (r *Rollout) UpdateService(svc *run.Service) (*run.Service, error) {
 		return svc, errors.Wrap(err, "failed to replace service")
 	}
 
-	diagnosis, err := r.diagnoseCandidate(candidate, r.strategy.Metrics)
+	diagnosis, err := r.diagnoseCandidate(candidate, r.strategy.HealthCriteria)
 	if err != nil {
 		r.log.Error("could not diagnose candidate's health")
 		return nil, errors.Wrapf(err, "failed to diagnose health for candidate %q", candidate)

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -242,7 +242,7 @@ func TestUpdateService(t *testing.T) {
 		svc := generateService(opts)
 		svcRecord := &rollout.ServiceRecord{Service: svc}
 
-		strategy.Metrics = test.healthCriteria
+		strategy.HealthCriteria = test.healthCriteria
 		lg := logrus.New()
 		lg.SetLevel(logrus.DebugLevel)
 		r := rollout.New(context.TODO(), metricsMock, svcRecord, strategy).WithClient(runclient).WithLogger(lg)


### PR DESCRIPTION
When reading the code, the name Metrics in the strategy is confusing. This renames this property to `HealthCriteria` for consistency across the code base and to make the code more readable.