### PR TITLE
health: Check for request count

### DIFF
--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -65,9 +65,17 @@ func Diagnose(ctx context.Context, healthCriteria []config.Metric, actualValues 
 			"threshold":   criteria.Threshold,
 			"actualValue": value,
 		})
+		isMet := isCriteriaMet(criteria.Type, criteria.Threshold, value)
+
+		// For unmet request count, return inconclusive and empty results.
+		if criteria.Type == config.RequestCountMetricsCheck && !isMet {
+			diagnosis = Inconclusive
+			results = nil
+			break
+		}
 
 		result := CheckResult{Threshold: criteria.Threshold, ActualValue: value}
-		if !isCriteriaMet(criteria.Type, criteria.Threshold, value) {
+		if !isMet {
 			logger.Debug("unmet criterion")
 			diagnosis = Unhealthy
 			results = append(results, result)
@@ -98,12 +106,12 @@ func CollectMetrics(ctx context.Context, provider metrics.Provider, offset time.
 		var err error
 
 		switch criteria.Type {
+		case config.RequestCountMetricsCheck:
+			metricsValue, err = requestCount(ctx, provider, offset)
 		case config.LatencyMetricsCheck:
 			metricsValue, err = latency(ctx, provider, offset, criteria.Percentile)
-			break
 		case config.ErrorRateMetricsCheck:
 			metricsValue, err = errorRatePercent(ctx, provider, offset)
-			break
 		default:
 			return nil, errors.Errorf("unimplemented metrics %q", criteria.Type)
 		}
@@ -119,14 +127,20 @@ func CollectMetrics(ctx context.Context, provider metrics.Provider, offset time.
 
 // isCriteriaMet concludes if metrics criteria was met.
 func isCriteriaMet(metricsType config.MetricsCheck, threshold float64, actualValue float64) bool {
-	// As of now, the supported health criteria (latency and error rate) need to
-	// be less than the threshold. So, this is sufficient for now but might need
-	// to change to a switch statement when criteria with a minimum threshold is
-	// added.
-	if actualValue <= threshold {
-		return true
+	// Of all the supported metrics, only the threshold for request count has an
+	// expected minimum value.
+	if metricsType == config.RequestCountMetricsCheck {
+		return actualValue >= threshold
 	}
-	return false
+	return actualValue <= threshold
+}
+
+// requestCount returns the number of requests during the given offset.
+func requestCount(ctx context.Context, provider metrics.Provider, offset time.Duration) (float64, error) {
+	logger := util.LoggerFromContext(ctx)
+	logger.Debug("querying for request count metrics")
+	count, err := provider.RequestCount(ctx, offset)
+	return float64(count), errors.Wrap(err, "failed to get request count metrics")
 }
 
 // latency returns the latency for the given offset and percentile.

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -68,7 +68,7 @@ func Diagnose(ctx context.Context, healthCriteria []config.Metric, actualValues 
 		isMet := isCriteriaMet(criteria.Type, criteria.Threshold, value)
 
 		// For unmet request count, return inconclusive and empty results.
-		if criteria.Type == config.RequestCountMetricsCheck && !isMet {
+		if !isMet && criteria.Type == config.RequestCountMetricsCheck {
 			diagnosis = Inconclusive
 			results = nil
 			break
@@ -83,7 +83,7 @@ func Diagnose(ctx context.Context, healthCriteria []config.Metric, actualValues 
 		}
 
 		// Only switch to healthy once a first criteria is met.
-		if diagnosis == Unknown {
+		if diagnosis == Unknown && criteria.Type != config.RequestCountMetricsCheck {
 			diagnosis = Healthy
 		}
 		result.IsCriteriaMet = true
@@ -137,7 +137,7 @@ func isCriteriaMet(metricsType config.MetricsCheck, threshold float64, actualVal
 
 // requestCount returns the number of requests during the given offset.
 func requestCount(ctx context.Context, provider metrics.Provider, offset time.Duration) (float64, error) {
-	logger := util.LoggerFromContext(ctx)
+	logger := util.LoggerFrom(ctx)
 	logger.Debug("querying for request count metrics")
 	count, err := provider.RequestCount(ctx, offset)
 	return float64(count), errors.Wrap(err, "failed to get request count metrics")

--- a/pkg/health/health_internal_test.go
+++ b/pkg/health/health_internal_test.go
@@ -1,0 +1,65 @@
+package health
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsCriteriaMet(t *testing.T) {
+	tests := []struct {
+		name        string
+		metricsType config.MetricsCheck
+		threshold   float64
+		actualValue float64
+		expected    bool
+	}{
+		{
+			name:        "met request count",
+			metricsType: config.RequestCountMetricsCheck,
+			threshold:   1000,
+			actualValue: 1000,
+			expected:    true,
+		},
+		{
+			name:        "met latency",
+			metricsType: config.LatencyMetricsCheck,
+			threshold:   750,
+			actualValue: 500,
+			expected:    true,
+		},
+		{
+			name:        "met error rate",
+			metricsType: config.ErrorRateMetricsCheck,
+			threshold:   1,
+			actualValue: 1,
+			expected:    true,
+		},
+		{
+			name:        "unmet request count",
+			metricsType: config.RequestCountMetricsCheck,
+			threshold:   1000,
+			actualValue: 700,
+		},
+		{
+			name:        "unmet latency",
+			metricsType: config.LatencyMetricsCheck,
+			threshold:   750,
+			actualValue: 751,
+		},
+		{
+			name:        "unmet error rate",
+			metricsType: config.ErrorRateMetricsCheck,
+			threshold:   1,
+			actualValue: 1.01,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isMet := isCriteriaMet(test.metricsType, test.threshold, test.actualValue)
+			assert.Equal(t, test.expected, isMet)
+		})
+	}
+}

--- a/pkg/health/health_internal_test.go
+++ b/pkg/health/health_internal_test.go
@@ -41,25 +41,28 @@ func TestIsCriteriaMet(t *testing.T) {
 			metricsType: config.RequestCountMetricsCheck,
 			threshold:   1000,
 			actualValue: 700,
+			expected:    false,
 		},
 		{
 			name:        "unmet latency",
 			metricsType: config.LatencyMetricsCheck,
 			threshold:   750,
 			actualValue: 751,
+			expected:    false,
 		},
 		{
 			name:        "unmet error rate",
 			metricsType: config.ErrorRateMetricsCheck,
 			threshold:   1,
 			actualValue: 1.01,
+			expected:    false,
 		},
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run(test.name, func(tt *testing.T) {
 			isMet := isCriteriaMet(test.metricsType, test.threshold, test.actualValue)
-			assert.Equal(t, test.expected, isMet)
+			assert.Equal(tt, test.expected, isMet)
 		})
 	}
 }

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -146,13 +146,13 @@ func TestDiagnosis(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run(test.name, func(tt *testing.T) {
 			ctx := context.Background()
 			diagnosis, err := health.Diagnose(ctx, test.healthCriteria, test.results)
 			if test.shouldErr {
-				assert.NotNil(t, err)
+				assert.NotNil(tt, err)
 			} else {
-				assert.Equal(t, test.expected, diagnosis)
+				assert.Equal(tt, test.expected, diagnosis)
 			}
 		})
 	}
@@ -181,6 +181,7 @@ func TestCollectMetrics(t *testing.T) {
 	}
 	expected := []float64{1000, 500.0, 1.0}
 
-	results, _ := health.CollectMetrics(ctx, metricsMock, offset, healthCriteria)
+	results, err := health.CollectMetrics(ctx, metricsMock, offset, healthCriteria)
+	assert.Nil(t, err)
 	assert.Equal(t, expected, results)
 }

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -63,6 +63,19 @@ func TestDiagnosis(t *testing.T) {
 			},
 		},
 		{
+			name: "only request count criteria, unknown",
+			healthCriteria: []config.Metric{
+				{Type: config.RequestCountMetricsCheck, Threshold: 1000},
+			},
+			results: []float64{1500},
+			expected: health.Diagnosis{
+				OverallResult: health.Unknown,
+				CheckResults: []health.CheckResult{
+					{Threshold: 1000, ActualValue: 1500, IsCriteriaMet: true},
+				},
+			},
+		},
+		{
 			name: "unhealthy revision, miss latency",
 			healthCriteria: []config.Metric{
 				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 499},


### PR DESCRIPTION
This adds health criteria checks for request count. If the criteria is not met, an inconclusive diagnosis is returned.