### PR TITLE
util: Rename LoggerFromContext to LoggerFrom

### DIFF
--- a/internal/metrics/sheets/sheets.go
+++ b/internal/metrics/sheets/sheets.go
@@ -70,7 +70,7 @@ func (p *Provider) SetCandidateRevision(revisionName string) {}
 
 // RequestCount returns the number of requests for the given offset.
 func (p *Provider) RequestCount(ctx context.Context, offset time.Duration) (int64, error) {
-	logger := util.LoggerFromContext(ctx)
+	logger := util.LoggerFrom(ctx)
 	logger.Debug("querying google sheet for request count")
 	serviceRow, err := p.retrieveServiceRow(logger)
 	if err != nil {
@@ -91,7 +91,7 @@ func (p *Provider) RequestCount(ctx context.Context, offset time.Duration) (int6
 
 // Latency returns the latency for the resource for the given offset.
 func (p *Provider) Latency(ctx context.Context, offset time.Duration, alignReduceType metrics.AlignReduce) (float64, error) {
-	logger := util.LoggerFromContext(ctx)
+	logger := util.LoggerFrom(ctx)
 	logger.Debug("querying google sheet for request count")
 	serviceRow, err := p.retrieveServiceRow(logger)
 	if err != nil {
@@ -124,7 +124,7 @@ func (p *Provider) Latency(ctx context.Context, offset time.Duration, alignReduc
 
 // ErrorRate returns the rate of 5xx errors for the resource matching the filter.
 func (p *Provider) ErrorRate(ctx context.Context, offset time.Duration) (float64, error) {
-	logger := util.LoggerFromContext(ctx)
+	logger := util.LoggerFrom(ctx)
 	logger.Debug("querying google sheet for request count")
 	serviceRow, err := p.retrieveServiceRow(logger)
 	if err != nil {

--- a/internal/run/wrapper.go
+++ b/internal/run/wrapper.go
@@ -68,7 +68,7 @@ func (a *API) ServicesWithLabelSelector(namespace string, labelSelector string) 
 
 // Regions gets the supported regions for the project.
 func Regions(ctx context.Context, project string) ([]string, error) {
-	logger := util.LoggerFromContext(ctx)
+	logger := util.LoggerFrom(ctx)
 	if len(regions) != 0 {
 		logger.Debug("using cached regions, skip querying from API")
 		return regions, nil

--- a/internal/stackdriver/stackdriver.go
+++ b/internal/stackdriver/stackdriver.go
@@ -71,7 +71,7 @@ func (p *Provider) RequestCount(ctx context.Context, offset time.Duration) (int6
 		AggregationGroupByFields("resource.labels.service_name").
 		AggregationCrossSeriesReducer("REDUCE_SUM")
 
-	logger := util.LoggerFromContext(ctx).WithFields(logrus.Fields{
+	logger := util.LoggerFrom(ctx).WithFields(logrus.Fields{
 		"intervalStartTime": startTimeString,
 		"intervalEndTime":   endTimeString,
 		"metrics":           "request-count",
@@ -114,7 +114,7 @@ func (p *Provider) Latency(ctx context.Context, offset time.Duration, alignReduc
 		AggregationGroupByFields("resource.labels.service_name").
 		AggregationCrossSeriesReducer(reducer)
 
-	logger := util.LoggerFromContext(ctx).WithFields(logrus.Fields{
+	logger := util.LoggerFrom(ctx).WithFields(logrus.Fields{
 		"intervalStartTime": startTimeString,
 		"intervalEndTime":   endTimeString,
 		"metrics":           "latency",
@@ -158,7 +158,7 @@ func (p *Provider) ErrorRate(ctx context.Context, offset time.Duration) (float64
 		AggregationGroupByFields("metric.labels.response_code_class").
 		AggregationCrossSeriesReducer("REDUCE_SUM")
 
-	logger := util.LoggerFromContext(ctx).WithFields(logrus.Fields{
+	logger := util.LoggerFrom(ctx).WithFields(logrus.Fields{
 		"intervalStartTime": startTimeString,
 		"intervalEndTime":   endTimeString,
 		"metrics":           "error-rate",

--- a/internal/util/context.go
+++ b/internal/util/context.go
@@ -17,8 +17,8 @@ func ContextWithLogger(ctx context.Context, logger *logrus.Entry) context.Contex
 	return context.WithValue(ctx, loggerKey, logger)
 }
 
-// LoggerFromContext returns the logger from the context.
-func LoggerFromContext(ctx context.Context) *logrus.Entry {
+// LoggerFrom returns the logger from the context.
+func LoggerFrom(ctx context.Context) *logrus.Entry {
 	value := ctx.Value(loggerKey)
 	logger, ok := value.(*logrus.Entry)
 	if !ok {

--- a/internal/util/context_test.go
+++ b/internal/util/context_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLoggerFromContext(t *testing.T) {
+func TestLoggerFrom(t *testing.T) {
 	tests := []struct {
 		name   string
 		logger *logrus.Logger
@@ -36,7 +36,7 @@ func TestLoggerFromContext(t *testing.T) {
 			ctx = util.ContextWithLogger(ctx, lg)
 		}
 
-		returnedLg := util.LoggerFromContext(ctx).Logger
+		returnedLg := util.LoggerFrom(ctx).Logger
 		assert.Equal(t, test.level, returnedLg.Level)
 	}
 }

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -47,7 +47,7 @@ type CheckResult struct {
 // Otherwise, all metrics criteria are checked to determine whether the revision
 // is healthy or not.
 func Diagnose(ctx context.Context, healthCriteria []config.Metric, actualValues []float64) (Diagnosis, error) {
-	logger := util.LoggerFromContext(ctx)
+	logger := util.LoggerFrom(ctx)
 	if len(healthCriteria) != len(actualValues) {
 		return Diagnosis{Unknown, nil}, errors.New("the size of health criteria is not the same to the size of the actual metrics values")
 	}
@@ -136,7 +136,7 @@ func latency(ctx context.Context, provider metrics.Provider, offset time.Duratio
 		return 0, errors.Wrap(err, "failed to parse percentile")
 	}
 
-	logger := util.LoggerFromContext(ctx).WithField("percentile", percentile)
+	logger := util.LoggerFrom(ctx).WithField("percentile", percentile)
 	logger.Debug("querying for latency metrics")
 	latency, err := provider.Latency(ctx, offset, alignerReducer)
 	if err != nil {
@@ -149,7 +149,7 @@ func latency(ctx context.Context, provider metrics.Provider, offset time.Duratio
 
 // errorRatePercent returns the percentage of errors during the given offset.
 func errorRatePercent(ctx context.Context, provider metrics.Provider, offset time.Duration) (float64, error) {
-	logger := util.LoggerFromContext(ctx)
+	logger := util.LoggerFrom(ctx)
 	logger.Debug("querying for error rate metrics")
 	rate, err := provider.ErrorRate(ctx, offset)
 	if err != nil {


### PR DESCRIPTION
Since it is clear we are getting the logger from the context, we can switch to a shorter name for the function. This closes #23 