### PR TITLE
rollout: Include health report in service object

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	cloud.google.com/go v0.60.0 // indirect
 	github.com/TV4/logrus-stackdriver-formatter v0.1.0
 	github.com/go-stack/stack v1.8.0 // indirect
-	github.com/google/go-cmp v0.5.0
 	github.com/mattn/go-isatty v0.0.12
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.6.0

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -22,6 +22,19 @@ const (
 	Unhealthy
 )
 
+func (d DiagnosisResult) String() string {
+	switch d {
+	case Inconclusive:
+		return "inconclusive"
+	case Healthy:
+		return "healthy"
+	case Unhealthy:
+		return "unhealthy"
+	default:
+		return "unknown"
+	}
+}
+
 // Diagnosis is the information about the health of the revision.
 type Diagnosis struct {
 	OverallResult DiagnosisResult

--- a/pkg/health/report.go
+++ b/pkg/health/report.go
@@ -8,10 +8,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// StringReport report generates a human-readable report of the diagnosis.
+// StringReport returns a human-readable report of the diagnosis.
 //
 // The returned string has the format:
-//
 // status: healthy
 // metrics:
 // - request-latency[p99]: 500.00 (threshold 750.0)

--- a/pkg/health/report.go
+++ b/pkg/health/report.go
@@ -1,0 +1,37 @@
+package health
+
+import (
+	"encoding/json"
+
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/config"
+	"github.com/pkg/errors"
+)
+
+// JSONReport returns a JSON representation of the diagnosis.
+func JSONReport(healthCriteria []config.Metric, diagnosis Diagnosis) (string, error) {
+	var resultsMap []map[string]interface{}
+	for i, result := range diagnosis.CheckResults {
+		criteria := healthCriteria[i]
+		report := map[string]interface{}{
+			"metricsType":   criteria.Type,
+			"threshold":     result.Threshold,
+			"actualValue":   result.ActualValue,
+			"isCriteriaMet": result.IsCriteriaMet,
+		}
+		if criteria.Type == config.LatencyMetricsCheck {
+			report["percentile"] = criteria.Percentile
+		}
+		resultsMap = append(resultsMap, report)
+	}
+
+	report := struct {
+		Diagnosis    string                   `json:"diagnosis"`
+		CheckResults []map[string]interface{} `json:"checkResults"`
+	}{
+		Diagnosis:    diagnosis.OverallResult.String(),
+		CheckResults: resultsMap,
+	}
+
+	reportJSON, err := json.Marshal(report)
+	return string(reportJSON), errors.Wrap(err, "failed to marshal report")
+}

--- a/pkg/health/report.go
+++ b/pkg/health/report.go
@@ -40,6 +40,9 @@ func StringReport(healthCriteria []config.Metric, diagnosis Diagnosis) string {
 }
 
 // JSONReport returns a JSON representation of the diagnosis.
+//
+// TODO: consider if this function is useful (e.g. for a dashboard) since it's
+// not used anywhere yet.
 func JSONReport(healthCriteria []config.Metric, diagnosis Diagnosis) (string, error) {
 	var resultsMap []map[string]interface{}
 	for i, result := range diagnosis.CheckResults {

--- a/pkg/health/report.go
+++ b/pkg/health/report.go
@@ -12,12 +12,12 @@ import (
 //
 // The returned string has the format:
 //
-// last status: healthy
+// status: healthy
 // metrics:
 // - request-latency[p99]: 500.00 (threshold 750.0)
 // - request-count: 800 (threshold 1000)
 func StringReport(healthCriteria []config.Metric, diagnosis Diagnosis) string {
-	report := fmt.Sprintf("last status: %s\n", diagnosis.OverallResult.String())
+	report := fmt.Sprintf("status: %s\n", diagnosis.OverallResult.String())
 	report += "metrics:"
 	for i, result := range diagnosis.CheckResults {
 		criteria := healthCriteria[i]

--- a/pkg/health/report.go
+++ b/pkg/health/report.go
@@ -1,11 +1,9 @@
 package health
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/config"
-	"github.com/pkg/errors"
 )
 
 // StringReport returns a human-readable report of the diagnosis.
@@ -13,8 +11,8 @@ import (
 // The returned string has the format:
 // status: healthy
 // metrics:
-// - request-latency[p99]: 500.00 (threshold 750.0)
-// - request-count: 800 (threshold 1000)
+// - request-latency[p99]: 500.00 (needs 750.0)
+// - request-count: 800 (needs 1000)
 func StringReport(healthCriteria []config.Metric, diagnosis Diagnosis) string {
 	report := fmt.Sprintf("status: %s\n", diagnosis.OverallResult.String())
 	report += "metrics:"
@@ -23,49 +21,17 @@ func StringReport(healthCriteria []config.Metric, diagnosis Diagnosis) string {
 
 		// Include percentile value for latency criteria.
 		if criteria.Type == config.LatencyMetricsCheck {
-			report += fmt.Sprintf("\n- %s[p%.0f]: %.2f (threshold %.2f)", criteria.Type, criteria.Percentile, result.ActualValue, criteria.Threshold)
+			report += fmt.Sprintf("\n- %s[p%.0f]: %.2f (needs %.2f)", criteria.Type, criteria.Percentile, result.ActualValue, criteria.Threshold)
 			continue
 		}
 
-		format := "\n- %s: %.2f (threshold %.2f)"
+		format := "\n- %s: %.2f (needs %.2f)"
 		if criteria.Type == config.RequestCountMetricsCheck {
 			// No decimals for request count.
-			format = "\n- %s: %.0f (threshold %.0f)"
+			format = "\n- %s: %.0f (needs %.0f)"
 		}
 		report += fmt.Sprintf(format, criteria.Type, result.ActualValue, criteria.Threshold)
 	}
 
 	return report
-}
-
-// JSONReport returns a JSON representation of the diagnosis.
-//
-// TODO: consider if this function is useful (e.g. for a dashboard) since it's
-// not used anywhere yet.
-func JSONReport(healthCriteria []config.Metric, diagnosis Diagnosis) (string, error) {
-	var resultsMap []map[string]interface{}
-	for i, result := range diagnosis.CheckResults {
-		criteria := healthCriteria[i]
-		report := map[string]interface{}{
-			"metricsType":   criteria.Type,
-			"threshold":     result.Threshold,
-			"actualValue":   result.ActualValue,
-			"isCriteriaMet": result.IsCriteriaMet,
-		}
-		if criteria.Type == config.LatencyMetricsCheck {
-			report["percentile"] = criteria.Percentile
-		}
-		resultsMap = append(resultsMap, report)
-	}
-
-	report := struct {
-		Diagnosis    string                   `json:"diagnosis"`
-		CheckResults []map[string]interface{} `json:"checkResults"`
-	}{
-		Diagnosis:    diagnosis.OverallResult.String(),
-		CheckResults: resultsMap,
-	}
-
-	reportJSON, err := json.Marshal(report)
-	return string(reportJSON), errors.Wrap(err, "failed to marshal report")
 }

--- a/pkg/health/report.go
+++ b/pkg/health/report.go
@@ -7,12 +7,6 @@ import (
 )
 
 // StringReport returns a human-readable report of the diagnosis.
-//
-// The returned string has the format:
-// status: healthy
-// metrics:
-// - request-latency[p99]: 500.00 (needs 750.0)
-// - request-count: 800 (needs 1000)
 func StringReport(healthCriteria []config.Metric, diagnosis Diagnosis) string {
 	report := fmt.Sprintf("status: %s\n", diagnosis.OverallResult.String())
 	report += "metrics:"

--- a/pkg/health/report.go
+++ b/pkg/health/report.go
@@ -2,10 +2,42 @@ package health
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/config"
 	"github.com/pkg/errors"
 )
+
+// StringReport report generates a human-readable report of the diagnosis.
+//
+// The returned string has the format:
+//
+// last status: healthy
+// metrics:
+// - request-latency[p99]: 500.00 (threshold 750.0)
+// - request-count: 800 (threshold 1000)
+func StringReport(healthCriteria []config.Metric, diagnosis Diagnosis) string {
+	report := fmt.Sprintf("last status: %s\n", diagnosis.OverallResult.String())
+	report += "metrics:"
+	for i, result := range diagnosis.CheckResults {
+		criteria := healthCriteria[i]
+
+		// Include percentile value for latency criteria.
+		if criteria.Type == config.LatencyMetricsCheck {
+			report += fmt.Sprintf("\n- %s[p%.0f]: %.2f (threshold %.2f)", criteria.Type, criteria.Percentile, result.ActualValue, criteria.Threshold)
+			continue
+		}
+
+		format := "\n- %s: %.2f (threshold %.2f)"
+		if criteria.Type == config.RequestCountMetricsCheck {
+			// No decimals for request count.
+			format = "\n- %s: %.0f (threshold %.0f)"
+		}
+		report += fmt.Sprintf(format, criteria.Type, result.ActualValue, criteria.Threshold)
+	}
+
+	return report
+}
 
 // JSONReport returns a JSON representation of the diagnosis.
 func JSONReport(healthCriteria []config.Metric, diagnosis Diagnosis) (string, error) {

--- a/pkg/health/report_test.go
+++ b/pkg/health/report_test.go
@@ -28,7 +28,7 @@ func TestStringReport(t *testing.T) {
 			},
 			expected: "status: unhealthy\n" +
 				"metrics:" +
-				"\n- request-latency[p99]: 1000.00 (threshold 750.00)",
+				"\n- request-latency[p99]: 1000.00 (needs 750.00)",
 		},
 		{
 			name: "more than one metrics",
@@ -47,9 +47,9 @@ func TestStringReport(t *testing.T) {
 			},
 			expected: "status: healthy\n" +
 				"metrics:" +
-				"\n- request-count: 1500 (threshold 1000)" +
-				"\n- request-latency[p99]: 500.00 (threshold 750.00)" +
-				"\n- error-rate-percent: 2.00 (threshold 5.00)",
+				"\n- request-count: 1500 (needs 1000)" +
+				"\n- request-latency[p99]: 500.00 (needs 750.00)" +
+				"\n- error-rate-percent: 2.00 (needs 5.00)",
 		},
 		{
 			name:     "no metrics",
@@ -60,58 +60,6 @@ func TestStringReport(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 			report := health.StringReport(test.healthCriteria, test.diagnosis)
-			assert.Equal(tt, test.expected, report)
-		})
-	}
-}
-
-func TestJSONReport(t *testing.T) {
-	tests := []struct {
-		name           string
-		healthCriteria []config.Metric
-		diagnosis      health.Diagnosis
-		expected       string
-	}{
-		{
-			name: "single metrics",
-			healthCriteria: []config.Metric{
-				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
-			},
-			diagnosis: health.Diagnosis{
-				OverallResult: health.Unhealthy,
-				CheckResults: []health.CheckResult{
-					{Threshold: 750, ActualValue: 1000, IsCriteriaMet: true},
-				},
-			},
-			expected: `{"diagnosis":"unhealthy","checkResults":[` +
-				`{"actualValue":1000,"isCriteriaMet":true,"metricsType":"request-latency","percentile":99,"threshold":750}]}`,
-		},
-		{
-			name: "more than one metrics",
-			healthCriteria: []config.Metric{
-				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
-				{Type: config.ErrorRateMetricsCheck, Threshold: 5},
-			},
-			diagnosis: health.Diagnosis{
-				OverallResult: health.Healthy,
-				CheckResults: []health.CheckResult{
-					{Threshold: 750, ActualValue: 500, IsCriteriaMet: true},
-					{Threshold: 5, ActualValue: 2, IsCriteriaMet: true},
-				},
-			},
-			expected: `{"diagnosis":"healthy","checkResults":[` +
-				`{"actualValue":500,"isCriteriaMet":true,"metricsType":"request-latency","percentile":99,"threshold":750},` +
-				`{"actualValue":2,"isCriteriaMet":true,"metricsType":"error-rate-percent","threshold":5}]}`,
-		},
-		{
-			name:     "no metrics",
-			expected: `{"diagnosis":"unknown","checkResults":null}`,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(tt *testing.T) {
-			report, _ := health.JSONReport(test.healthCriteria, test.diagnosis)
 			assert.Equal(tt, test.expected, report)
 		})
 	}

--- a/pkg/health/report_test.go
+++ b/pkg/health/report_test.go
@@ -8,7 +8,64 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHealthReportAnnotation(t *testing.T) {
+func TestStringReport(t *testing.T) {
+	tests := []struct {
+		name           string
+		healthCriteria []config.Metric
+		diagnosis      health.Diagnosis
+		expected       string
+	}{
+		{
+			name: "single metrics",
+			healthCriteria: []config.Metric{
+				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
+			},
+			diagnosis: health.Diagnosis{
+				OverallResult: health.Unhealthy,
+				CheckResults: []health.CheckResult{
+					{Threshold: 750, ActualValue: 1000, IsCriteriaMet: true},
+				},
+			},
+			expected: "last status: unhealthy\n" +
+				"metrics:" +
+				"\n- request-latency[p99]: 1000.00 (threshold 750.00)",
+		},
+		{
+			name: "more than one metrics",
+			healthCriteria: []config.Metric{
+				{Type: config.RequestCountMetricsCheck, Threshold: 1000},
+				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
+				{Type: config.ErrorRateMetricsCheck, Threshold: 5},
+			},
+			diagnosis: health.Diagnosis{
+				OverallResult: health.Healthy,
+				CheckResults: []health.CheckResult{
+					{Threshold: 1000, ActualValue: 1500, IsCriteriaMet: true},
+					{Threshold: 750, ActualValue: 500, IsCriteriaMet: true},
+					{Threshold: 5, ActualValue: 2, IsCriteriaMet: true},
+				},
+			},
+			expected: "last status: healthy\n" +
+				"metrics:" +
+				"\n- request-count: 1500 (threshold 1000)" +
+				"\n- request-latency[p99]: 500.00 (threshold 750.00)" +
+				"\n- error-rate-percent: 2.00 (threshold 5.00)",
+		},
+		{
+			name:     "no metrics",
+			expected: "last status: unknown\nmetrics:",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			report := health.StringReport(test.healthCriteria, test.diagnosis)
+			assert.Equal(tt, test.expected, report)
+		})
+	}
+}
+
+func TestJSONReport(t *testing.T) {
 	tests := []struct {
 		name           string
 		healthCriteria []config.Metric
@@ -53,9 +110,9 @@ func TestHealthReportAnnotation(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run(test.name, func(tt *testing.T) {
 			report, _ := health.JSONReport(test.healthCriteria, test.diagnosis)
-			assert.Equal(t, test.expected, report)
+			assert.Equal(tt, test.expected, report)
 		})
 	}
 }

--- a/pkg/health/report_test.go
+++ b/pkg/health/report_test.go
@@ -26,7 +26,7 @@ func TestStringReport(t *testing.T) {
 					{Threshold: 750, ActualValue: 1000, IsCriteriaMet: true},
 				},
 			},
-			expected: "last status: unhealthy\n" +
+			expected: "status: unhealthy\n" +
 				"metrics:" +
 				"\n- request-latency[p99]: 1000.00 (threshold 750.00)",
 		},
@@ -45,7 +45,7 @@ func TestStringReport(t *testing.T) {
 					{Threshold: 5, ActualValue: 2, IsCriteriaMet: true},
 				},
 			},
-			expected: "last status: healthy\n" +
+			expected: "status: healthy\n" +
 				"metrics:" +
 				"\n- request-count: 1500 (threshold 1000)" +
 				"\n- request-latency[p99]: 500.00 (threshold 750.00)" +
@@ -53,7 +53,7 @@ func TestStringReport(t *testing.T) {
 		},
 		{
 			name:     "no metrics",
-			expected: "last status: unknown\nmetrics:",
+			expected: "status: unknown\nmetrics:",
 		},
 	}
 

--- a/pkg/health/report_test.go
+++ b/pkg/health/report_test.go
@@ -1,0 +1,61 @@
+package health_test
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/config"
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/health"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHealthReportAnnotation(t *testing.T) {
+	tests := []struct {
+		name           string
+		healthCriteria []config.Metric
+		diagnosis      health.Diagnosis
+		expected       string
+	}{
+		{
+			name: "single metrics",
+			healthCriteria: []config.Metric{
+				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
+			},
+			diagnosis: health.Diagnosis{
+				OverallResult: health.Unhealthy,
+				CheckResults: []health.CheckResult{
+					{Threshold: 750, ActualValue: 1000, IsCriteriaMet: true},
+				},
+			},
+			expected: `{"diagnosis":"unhealthy","checkResults":[` +
+				`{"actualValue":1000,"isCriteriaMet":true,"metricsType":"request-latency","percentile":99,"threshold":750}]}`,
+		},
+		{
+			name: "more than one metrics",
+			healthCriteria: []config.Metric{
+				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
+				{Type: config.ErrorRateMetricsCheck, Threshold: 5},
+			},
+			diagnosis: health.Diagnosis{
+				OverallResult: health.Healthy,
+				CheckResults: []health.CheckResult{
+					{Threshold: 750, ActualValue: 500, IsCriteriaMet: true},
+					{Threshold: 5, ActualValue: 2, IsCriteriaMet: true},
+				},
+			},
+			expected: `{"diagnosis":"healthy","checkResults":[` +
+				`{"actualValue":500,"isCriteriaMet":true,"metricsType":"request-latency","percentile":99,"threshold":750},` +
+				`{"actualValue":2,"isCriteriaMet":true,"metricsType":"error-rate-percent","threshold":5}]}`,
+		},
+		{
+			name:     "no metrics",
+			expected: `{"diagnosis":"unknown","checkResults":null}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			report, _ := health.JSONReport(test.healthCriteria, test.diagnosis)
+			assert.Equal(t, test.expected, report)
+		})
+	}
+}

--- a/pkg/rollout/revision.go
+++ b/pkg/rollout/revision.go
@@ -4,13 +4,6 @@ import (
 	"google.golang.org/api/run/v1"
 )
 
-// Annotations name for information related to the rollout.
-const (
-	StableRevisionAnnotation              = "rollout.cloud.run/stableRevision"
-	CandidateRevisionAnnotation           = "rollout.cloud.run/candidateRevision"
-	LastFailedCandidateRevisionAnnotation = "rollout.cloud.run/lastFailedCandidateRevision"
-)
-
 // DetectStableRevisionName returns the stable revision of the Cloud Run service.
 //
 // It first checks if there's a revision with the tag "stable". If such a

--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -148,10 +148,7 @@ func (r *Rollout) UpdateService(svc *run.Service) (*run.Service, error) {
 		return nil, errors.Errorf("invalid candidate's health diagnosis %v", diagnosis.OverallResult)
 	}
 
-	report, err := health.JSONReport(r.strategy.HealthCriteria, diagnosis)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate health report")
-	}
+	report := health.StringReport(r.strategy.HealthCriteria, diagnosis)
 	svc = r.updateAnnotations(svc, stable, candidate, report)
 	err = r.replaceService(svc)
 	return svc, errors.Wrap(err, "failed to replace service")

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -147,7 +147,7 @@ func TestUpdateService(t *testing.T) {
 				{Type: config.ErrorRateMetricsCheck, Threshold: 5},
 			},
 			outAnnotations: map[string]string{
-				rollout.LastHealthReportAnnotation: "last status: healthy\n" +
+				rollout.LastHealthReportAnnotation: "status: healthy\n" +
 					"metrics:" +
 					"\n- request-latency[p99]: 500.00 (threshold 750.00)" +
 					"\n- error-rate-percent: 1.00 (threshold 5.00)",
@@ -193,7 +193,7 @@ func TestUpdateService(t *testing.T) {
 				{Type: config.ErrorRateMetricsCheck, Threshold: 5},
 			},
 			outAnnotations: map[string]string{
-				rollout.LastHealthReportAnnotation: "last status: healthy\n" +
+				rollout.LastHealthReportAnnotation: "status: healthy\n" +
 					"metrics:" +
 					"\n- request-latency[p99]: 500.00 (threshold 750.00)" +
 					"\n- error-rate-percent: 1.00 (threshold 5.00)",
@@ -217,7 +217,7 @@ func TestUpdateService(t *testing.T) {
 				{Type: config.ErrorRateMetricsCheck, Threshold: 0.95},
 			},
 			outAnnotations: map[string]string{
-				rollout.LastHealthReportAnnotation: "last status: unhealthy\n" +
+				rollout.LastHealthReportAnnotation: "status: unhealthy\n" +
 					"metrics:" +
 					"\n- request-latency[p99]: 500.00 (threshold 100.00)" +
 					"\n- error-rate-percent: 1.00 (threshold 0.95)",

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -147,9 +147,10 @@ func TestUpdateService(t *testing.T) {
 				{Type: config.ErrorRateMetricsCheck, Threshold: 5},
 			},
 			outAnnotations: map[string]string{
-				rollout.LastHealthReportAnnotation: `{"diagnosis":"healthy","checkResults":[` +
-					`{"actualValue":500,"isCriteriaMet":true,"metricsType":"request-latency","percentile":99,"threshold":750},` +
-					`{"actualValue":1,"isCriteriaMet":true,"metricsType":"error-rate-percent","threshold":5}]}`,
+				rollout.LastHealthReportAnnotation: "last status: healthy\n" +
+					"metrics:" +
+					"\n- request-latency[p99]: 500.00 (threshold 750.00)" +
+					"\n- error-rate-percent: 1.00 (threshold 5.00)",
 				rollout.StableRevisionAnnotation:    "test-001",
 				rollout.CandidateRevisionAnnotation: "test-002",
 			},
@@ -192,9 +193,10 @@ func TestUpdateService(t *testing.T) {
 				{Type: config.ErrorRateMetricsCheck, Threshold: 5},
 			},
 			outAnnotations: map[string]string{
-				rollout.LastHealthReportAnnotation: `{"diagnosis":"healthy","checkResults":[` +
-					`{"actualValue":500,"isCriteriaMet":true,"metricsType":"request-latency","percentile":99,"threshold":750},` +
-					`{"actualValue":1,"isCriteriaMet":true,"metricsType":"error-rate-percent","threshold":5}]}`,
+				rollout.LastHealthReportAnnotation: "last status: healthy\n" +
+					"metrics:" +
+					"\n- request-latency[p99]: 500.00 (threshold 750.00)" +
+					"\n- error-rate-percent: 1.00 (threshold 5.00)",
 				rollout.StableRevisionAnnotation: "test-002",
 			},
 			outTraffic: []*run.TrafficTarget{
@@ -215,9 +217,10 @@ func TestUpdateService(t *testing.T) {
 				{Type: config.ErrorRateMetricsCheck, Threshold: 0.95},
 			},
 			outAnnotations: map[string]string{
-				rollout.LastHealthReportAnnotation: `{"diagnosis":"unhealthy","checkResults":[` +
-					`{"actualValue":500,"isCriteriaMet":false,"metricsType":"request-latency","percentile":99,"threshold":100},` +
-					`{"actualValue":1,"isCriteriaMet":false,"metricsType":"error-rate-percent","threshold":0.95}]}`,
+				rollout.LastHealthReportAnnotation: "last status: unhealthy\n" +
+					"metrics:" +
+					"\n- request-latency[p99]: 500.00 (threshold 100.00)" +
+					"\n- error-rate-percent: 1.00 (threshold 0.95)",
 				rollout.StableRevisionAnnotation:              "test-001",
 				rollout.CandidateRevisionAnnotation:           "test-002",
 				rollout.LastFailedCandidateRevisionAnnotation: "test-002",

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -149,8 +149,8 @@ func TestUpdateService(t *testing.T) {
 			outAnnotations: map[string]string{
 				rollout.LastHealthReportAnnotation: "status: healthy\n" +
 					"metrics:" +
-					"\n- request-latency[p99]: 500.00 (threshold 750.00)" +
-					"\n- error-rate-percent: 1.00 (threshold 5.00)",
+					"\n- request-latency[p99]: 500.00 (needs 750.00)" +
+					"\n- error-rate-percent: 1.00 (needs 5.00)",
 				rollout.StableRevisionAnnotation:    "test-001",
 				rollout.CandidateRevisionAnnotation: "test-002",
 			},
@@ -195,8 +195,8 @@ func TestUpdateService(t *testing.T) {
 			outAnnotations: map[string]string{
 				rollout.LastHealthReportAnnotation: "status: healthy\n" +
 					"metrics:" +
-					"\n- request-latency[p99]: 500.00 (threshold 750.00)" +
-					"\n- error-rate-percent: 1.00 (threshold 5.00)",
+					"\n- request-latency[p99]: 500.00 (needs 750.00)" +
+					"\n- error-rate-percent: 1.00 (needs 5.00)",
 				rollout.StableRevisionAnnotation: "test-002",
 			},
 			outTraffic: []*run.TrafficTarget{
@@ -219,8 +219,8 @@ func TestUpdateService(t *testing.T) {
 			outAnnotations: map[string]string{
 				rollout.LastHealthReportAnnotation: "status: unhealthy\n" +
 					"metrics:" +
-					"\n- request-latency[p99]: 500.00 (threshold 100.00)" +
-					"\n- error-rate-percent: 1.00 (threshold 0.95)",
+					"\n- request-latency[p99]: 500.00 (needs 100.00)" +
+					"\n- error-rate-percent: 1.00 (needs 0.95)",
 				rollout.StableRevisionAnnotation:              "test-001",
 				rollout.CandidateRevisionAnnotation:           "test-002",
 				rollout.LastFailedCandidateRevisionAnnotation: "test-002",


### PR DESCRIPTION
This adds annotation about the last health report. It uses the key rollout.cloud.run/lastHealthReport and assigns it a string with the last diagnosis (healthy, unhealthy) and the check results. 
