### PR TITLE
main: Support rollouts through HTTP requests

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -58,7 +58,7 @@ var (
 	flLoggingLevel       string
 	flCLI                bool
 	flCLILoopIntervalSec int
-	flPort               int
+	flHTTPAddr           string
 	flProject            string
 	flLabelSelector      string
 
@@ -81,19 +81,15 @@ var (
 )
 
 func init() {
-	defaultPort := 8080
+	defaultAddr := ":8080"
 	if v := os.Getenv("PORT"); v != "" {
-		var err error
-		defaultPort, err = strconv.Atoi(v)
-		if err != nil {
-			logrus.WithField("v", v).Fatalf("invalid PORT environment variable, expected int")
-		}
+		defaultAddr = fmt.Sprintf(":%s", v)
 	}
 
 	flag.StringVar(&flLoggingLevel, "verbosity", "info", "the logging level (e.g. debug)")
 	flag.BoolVar(&flCLI, "cli", false, "run as CLI application to manage rollout in intervals")
 	flag.IntVar(&flCLILoopIntervalSec, "cli-run-interval", 60, "the time between each rollout process (in seconds)")
-	flag.IntVar(&flPort, "-port", defaultPort, "port where to listen to http requests (e.g. 8080)")
+	flag.StringVar(&flHTTPAddr, "http-addr", defaultAddr, "port where to listen to http requests (e.g. 8080)")
 	flag.StringVar(&flProject, "project", "", "project in which the service is deployed")
 	flag.StringVar(&flLabelSelector, "label", "rollout-strategy=gradual", "filter services based on a label (e.g. team=backend)")
 	flag.StringVar(&flRegionsString, "regions", "", "the Cloud Run regions where the service should be looked at")
@@ -150,9 +146,8 @@ func main() {
 		runDaemon(ctx, logger, cfg)
 	} else {
 		http.HandleFunc("/rollout", makeRolloutHandler(logger, cfg))
-		logger.WithField("port", flPort).Infof("starting server")
-		port := fmt.Sprintf(":%d", flPort)
-		logger.Fatal(http.ListenAndServe(port, nil))
+		logger.WithField("addr", flHTTPAddr).Infof("starting server")
+		logger.Fatal(http.ListenAndServe(flHTTPAddr, nil))
 	}
 }
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -143,7 +143,8 @@ func main() {
 		}
 	}
 
-	http.HandleFunc("/", makeRolloutHandler(logger, cfg))
+	http.HandleFunc("/rollout", makeRolloutHandler(logger, cfg))
+	logger.Infof("starting server at %s", flHTTPAddr)
 	logger.Fatal(http.ListenAndServe(flHTTPAddr, nil))
 }
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -89,7 +89,7 @@ func init() {
 	flag.StringVar(&flLoggingLevel, "verbosity", "info", "the logging level (e.g. debug)")
 	flag.BoolVar(&flCLI, "cli", false, "run as CLI application to manage rollout in intervals")
 	flag.IntVar(&flCLILoopIntervalSec, "cli-run-interval", 60, "the time between each rollout process (in seconds)")
-	flag.StringVar(&flHTTPAddr, "http-addr", defaultAddr, "port where to listen to http requests (e.g. 8080)")
+	flag.StringVar(&flHTTPAddr, "http-addr", defaultAddr, "address where to listen to http requests (e.g. :8080)")
 	flag.StringVar(&flProject, "project", "", "project in which the service is deployed")
 	flag.StringVar(&flLabelSelector, "label", "rollout-strategy=gradual", "filter services based on a label (e.g. team=backend)")
 	flag.StringVar(&flRegionsString, "regions", "", "the Cloud Run regions where the service should be looked at")
@@ -156,7 +156,7 @@ func runDaemon(ctx context.Context, logger *logrus.Logger, cfg *config.Config) {
 		errs := runRollouts(ctx, logger, cfg)
 		errsStr := rolloutErrsToString(errs)
 		if len(errs) != 0 {
-			logger.Warnf("there were %d errors: %s", len(errs), errsStr)
+			logger.Warnf("there were %d errors: \n%s", len(errs), errsStr)
 		}
 
 		duration := time.Duration(flCLILoopIntervalSec)

--- a/cmd/operator/rollout.go
+++ b/cmd/operator/rollout.go
@@ -33,6 +33,7 @@ func runRollouts(ctx context.Context, logger *logrus.Logger, cfg *config.Config)
 			defer wg.Done()
 			err := handleRollout(ctx, lg, svc, strategy)
 			if err != nil {
+				lg.Debugf("rollout error for service %q: %+v", svc.Service.Metadata.Name, err)
 				mu.Lock()
 				errs = append(errs, err)
 				mu.Unlock()
@@ -80,7 +81,10 @@ func handleRollout(ctx context.Context, logger *logrus.Logger, service *rollout.
 // during the rollout of all targeted services.
 func rolloutErrsToString(errs []error) (errsStr string) {
 	for i, err := range errs {
-		errsStr += fmt.Sprintf("\n[error#%d] %v", i, err)
+		if i > 0 {
+			errsStr += "\n"
+		}
+		errsStr += fmt.Sprintf("[error#%d] %v", i, err)
 	}
 	return errsStr
 }

--- a/cmd/operator/rollout.go
+++ b/cmd/operator/rollout.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	runapi "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/run"
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/config"
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/rollout"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// runRollouts concurrently handles the rollout of the targeted services.
+func runRollouts(ctx context.Context, logger *logrus.Logger, svcs []*rollout.ServiceRecord, strategy *config.Strategy) []error {
+	var (
+		errs []error
+		mu   sync.Mutex
+		wg   sync.WaitGroup
+	)
+	for _, svc := range svcs {
+		wg.Add(1)
+		go func(ctx context.Context, lg *logrus.Logger, svc *rollout.ServiceRecord, strategy *config.Strategy) {
+			err := handleRollout(ctx, lg, svc, strategy)
+			if err != nil {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
+			}
+			wg.Done()
+		}(ctx, logger, svc, strategy)
+	}
+	wg.Wait()
+
+	return errs
+}
+
+// handleRollout manages the rollout process for a single service.
+func handleRollout(ctx context.Context, logger *logrus.Logger, service *rollout.ServiceRecord, strategy *config.Strategy) error {
+	lg := logger.WithFields(logrus.Fields{
+		"project": service.Project,
+		"service": service.Metadata.Name,
+		"region":  service.Region,
+	})
+
+	client, err := runapi.NewAPIClient(ctx, service.Region)
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize Cloud Run API client")
+	}
+	metricsProvider, err := chooseMetricsProvider(ctx, lg, service.Project, service.Region, service.Metadata.Name)
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize metrics provider")
+	}
+	roll := rollout.New(ctx, metricsProvider, service, strategy).WithClient(client).WithLogger(lg.Logger)
+
+	changed, err := roll.Rollout()
+	if err != nil {
+		lg.Errorf("rollout failed, error=%v", err)
+		return errors.Wrap(err, "rollout failed")
+	}
+
+	if changed {
+		lg.Info("service was successfully updated")
+	} else {
+		lg.Debug("service kept unchanged")
+	}
+	return nil
+}
+
+// rolloutErrsToString returns the string representation of all the errors found
+// during the rollout of all targeted services.
+func rolloutErrsToString(errs []error) (errsStr string) {
+	for i, err := range errs {
+		errsStr += fmt.Sprintf("\n[error#%d] %v", i, err)
+	}
+	return errsStr
+}

--- a/cmd/operator/server.go
+++ b/cmd/operator/server.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+// makeRolloutHandler creates a request handler to perform a rollout process.
+func makeRolloutHandler(logger *logrus.Logger, cfg *config.Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		services, err := getTargetedServices(ctx, logger, cfg.Targets)
+		if err != nil {
+			logger.Errorf("failed to get targeted services: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "failed to retrieved services %v", err)
+			return
+		}
+		if len(services) == 0 {
+			logger.Warn("no service matches the targets")
+		}
+
+		// TODO(gvso): Filter "fatal" errors from "no-bad" errors (e.g. no
+		// requests in interval when getting metrics).
+		errs := runRollouts(ctx, logger, services, cfg.Strategy)
+		errsStr := rolloutErrsToString(errs)
+		if len(errs) != 0 {
+			msg := fmt.Sprintf("there were %d errors: %s", len(errs), errsStr)
+			logger.Warn(msg)
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, msg)
+		}
+	}
+}

--- a/cmd/operator/server.go
+++ b/cmd/operator/server.go
@@ -12,20 +12,7 @@ import (
 func makeRolloutHandler(logger *logrus.Logger, cfg *config.Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
-		services, err := getTargetedServices(ctx, logger, cfg.Targets)
-		if err != nil {
-			logger.Errorf("failed to get targeted services: %v", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, "failed to retrieved services %v", err)
-			return
-		}
-		if len(services) == 0 {
-			logger.Warn("no service matches the targets")
-		}
-
-		// TODO(gvso): Filter "fatal" errors from "no-bad" errors (e.g. no
-		// requests in interval when getting metrics).
-		errs := runRollouts(ctx, logger, services, cfg.Strategy)
+		errs := runRollouts(ctx, logger, cfg)
 		errsStr := rolloutErrsToString(errs)
 		if len(errs) != 0 {
 			msg := fmt.Sprintf("there were %d errors: %s", len(errs), errsStr)

--- a/cmd/operator/server.go
+++ b/cmd/operator/server.go
@@ -15,7 +15,7 @@ func makeRolloutHandler(logger *logrus.Logger, cfg *config.Config) http.HandlerF
 		errs := runRollouts(ctx, logger, cfg)
 		errsStr := rolloutErrsToString(errs)
 		if len(errs) != 0 {
-			msg := fmt.Sprintf("there were %d errors: %s", len(errs), errsStr)
+			msg := fmt.Sprintf("there were %d errors: \n%s", len(errs), errsStr)
 			logger.Warn(msg)
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprint(w, msg)


### PR DESCRIPTION
This creates an HTTP server when a port is specified using `-http-addr`. It also separates the rollout logic for reuse.
