### PR TITLE
rollout: Roll forward only if enough time passed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go v0.60.0 // indirect
 	github.com/TV4/logrus-stackdriver-formatter v0.1.0
 	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/jonboulle/clockwork v0.2.0
 	github.com/mattn/go-isatty v0.0.12
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/jonboulle/clockwork v0.2.0 h1:J2SLSdy7HgElq8ekSl2Mxh6vrRNFxqbXGenYH2I02Vs=
+github.com/jonboulle/clockwork v0.2.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=

--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -343,7 +343,6 @@ func (r *Rollout) updateAnnotations(svc *run.Service, stable, candidate string) 
 	if r.promoteToStable {
 		setAnnotation(svc, StableRevisionAnnotation, candidate)
 		delete(svc.Metadata.Annotations, CandidateRevisionAnnotation)
-		svc.Metadata.Annotations[LastRolloutAnnotation] = now
 		return svc
 	}
 

--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -10,6 +10,7 @@ import (
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/util"
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/config"
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/health"
+	"github.com/jonboulle/clockwork"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/run/v1"
@@ -20,6 +21,7 @@ const (
 	StableRevisionAnnotation              = "rollout.cloud.run/stableRevision"
 	CandidateRevisionAnnotation           = "rollout.cloud.run/candidateRevision"
 	LastFailedCandidateRevisionAnnotation = "rollout.cloud.run/lastFailedCandidateRevision"
+	LastRolloutAnnotation                 = "rollout.cloud.run/lastRollout"
 	LastHealthReportAnnotation            = "rollout.cloud.run/lastHealthReport"
 )
 
@@ -41,6 +43,7 @@ type Rollout struct {
 	strategy        *config.Strategy
 	runClient       runapi.Client
 	log             *logrus.Entry
+	time            clockwork.Clock
 
 	// Used to determine if candidate should become stable during update.
 	promoteToStable bool
@@ -70,6 +73,7 @@ func New(ctx context.Context, metricsProvider metrics.Provider, svcRecord *Servi
 		region:          svcRecord.Region,
 		strategy:        strategy,
 		log:             logrus.NewEntry(logrus.New()),
+		time:            clockwork.NewRealClock(),
 	}
 }
 
@@ -82,6 +86,12 @@ func (r *Rollout) WithClient(client runapi.Client) *Rollout {
 // WithLogger updates the logger in the rollout instance.
 func (r *Rollout) WithLogger(logger *logrus.Logger) *Rollout {
 	r.log = logger.WithField("project", r.project)
+	return r
+}
+
+// WithClock updates the clock in the rollout instance.
+func (r *Rollout) WithClock(clock clockwork.Clock) *Rollout {
+	r.time = clock
 	return r
 }
 
@@ -138,19 +148,15 @@ func (r *Rollout) UpdateService(svc *run.Service) (*run.Service, error) {
 		return nil, errors.Wrapf(err, "failed to diagnose health for candidate %q", candidate)
 	}
 
-	switch diagnosis.OverallResult {
-	case health.Inconclusive:
-		r.log.Debug("health check inconclusive")
+	svc, err = r.updateServiceBasedOnDiagnosis(svc, diagnosis.OverallResult, stable, candidate)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update service after diagnosis")
+	}
+	if svc == nil {
+		// If service was unchanged, nil is returned.
+		// TODO(gvso): This should go away once we start getting traffic config
+		// object from updateServiceBasedOnDiagnosis.
 		return nil, nil
-	case health.Healthy:
-		r.log.Debug("healthy candidate, roll forward")
-		svc = r.PrepareRollForward(svc, stable, candidate)
-	case health.Unhealthy:
-		r.log.Info("unhealthy candidate, rollback")
-		r.shouldRollback = true
-		svc = r.PrepareRollback(svc, stable, candidate)
-	default:
-		return nil, errors.Errorf("invalid candidate's health diagnosis %v", diagnosis.OverallResult)
 	}
 
 	svc = r.updateAnnotations(svc, stable, candidate)
@@ -210,6 +216,41 @@ func (r *Rollout) PrepareRollback(svc *run.Service, stable, candidate string) *r
 
 	svc.Spec.Traffic = traffic
 	return svc
+}
+
+// updateServiceBasedOnDiagnosis updates a service's traffic configuration
+// based on the diagnosis.
+// If service was unchanged, nil is returned.
+//
+// TODO (gvso): Refactor this and other methods to return only a traffic object.
+// Then, rename this to trafficBasedOnDiagnosis.
+// Also, move those traffic-config-related methods to traffic.go file.
+func (r *Rollout) updateServiceBasedOnDiagnosis(svc *run.Service, diagnosis health.DiagnosisResult, stable, candidate string) (*run.Service, error) {
+	switch diagnosis {
+	case health.Inconclusive:
+		r.log.Debug("health check inconclusive")
+		return nil, nil
+	case health.Healthy:
+		r.log.Debug("healthy candidate")
+		enoughTime, err := r.hasEnoughTimeElapsed(svc.Metadata.Annotations[LastRolloutAnnotation], r.strategy.TimeBetweenRollouts)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not determine if roll out is allowed")
+		}
+		if !enoughTime {
+			r.log.Debug("no enough time since last roll out, service unchanged")
+			return nil, nil
+		}
+		r.log.Debug("rolling forward")
+		svc = r.PrepareRollForward(svc, stable, candidate)
+	case health.Unhealthy:
+		r.log.Info("unhealthy candidate, rollback")
+		r.shouldRollback = true
+		svc = r.PrepareRollback(svc, stable, candidate)
+	default:
+		return nil, errors.Errorf("invalid candidate's health diagnosis %v", diagnosis)
+	}
+
+	return svc, nil
 }
 
 // replaceService updates the service object in Cloud Run.
@@ -294,10 +335,14 @@ func (r *Rollout) nextCandidateTraffic(current int64) int64 {
 
 // updateAnnotations updates the annotations to keep some state about the rollout.
 func (r *Rollout) updateAnnotations(svc *run.Service, stable, candidate string) *run.Service {
+	now := r.time.Now().Format(time.RFC3339)
+	setAnnotation(svc, LastRolloutAnnotation, now)
+
 	// The candidate has become the stable revision.
 	if r.promoteToStable {
 		setAnnotation(svc, StableRevisionAnnotation, candidate)
 		delete(svc.Metadata.Annotations, CandidateRevisionAnnotation)
+		svc.Metadata.Annotations[LastRolloutAnnotation] = now
 		return svc
 	}
 
@@ -332,6 +377,23 @@ func (r *Rollout) diagnoseCandidate(candidate string, healthCriteria []config.Me
 	r.log.Debug("diagnosing candidate's health")
 	d, err = health.Diagnose(ctx, healthCriteria, metricsValues)
 	return d, errors.Wrap(err, "failed to diagnose candidate's health")
+}
+
+// hasEnoughTimeElapsed determines if enough time has elapsed since last
+// rollout.
+//
+// TODO: what if lastRolloutStr is always invalid?
+func (r *Rollout) hasEnoughTimeElapsed(lastRolloutStr string, timeBetweenRollouts time.Duration) (bool, error) {
+	if lastRolloutStr == "" {
+		return false, errors.Errorf("%s annotation is missing", LastRolloutAnnotation)
+	}
+	lastRollout, err := time.Parse(time.RFC3339, lastRolloutStr)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to parse last roll out time")
+	}
+
+	currentTime := r.time.Now()
+	return currentTime.Sub(lastRollout) >= timeBetweenRollouts, nil
 }
 
 // newTrafficTarget returns a new traffic target instance.

--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -232,12 +232,13 @@ func (r *Rollout) updateServiceBasedOnDiagnosis(svc *run.Service, diagnosis heal
 		return nil, nil
 	case health.Healthy:
 		r.log.Debug("healthy candidate")
-		enoughTime, err := r.hasEnoughTimeElapsed(svc.Metadata.Annotations[LastRolloutAnnotation], r.strategy.TimeBetweenRollouts)
+		lastRollout := svc.Metadata.Annotations[LastRolloutAnnotation]
+		enoughTime, err := r.hasEnoughTimeElapsed(lastRollout, r.strategy.TimeBetweenRollouts)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not determine if roll out is allowed")
 		}
 		if !enoughTime {
-			r.log.Debug("no enough time since last roll out, service unchanged")
+			r.log.WithField("lastRollout", lastRollout).Debug("no enough time elapsed since last roll out")
 			return nil, nil
 		}
 		r.log.Debug("rolling forward")

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -142,7 +142,7 @@ func TestUpdateService(t *testing.T) {
 			},
 		},
 		{
-			name: "keep rolling forward the same candidate",
+			name: "keep rolling out the same candidate",
 			traffic: []*run.TrafficTarget{
 				{RevisionName: "test-001", Percent: 100 - strategy.Steps[1], Tag: rollout.StableTag},
 				{RevisionName: "test-002", Percent: strategy.Steps[1], Tag: rollout.CandidateTag},
@@ -259,7 +259,6 @@ func TestUpdateService(t *testing.T) {
 			outAnnotations: map[string]string{
 				rollout.StableRevisionAnnotation:              "test-001",
 				rollout.CandidateRevisionAnnotation:           "test-002",
-				rollout.LastRolloutAnnotation:                 makeLastRolloutAnnotation(clockMock, 0),
 				rollout.LastFailedCandidateRevisionAnnotation: "test-002",
 				rollout.LastRolloutAnnotation:                 makeLastRolloutAnnotation(clockMock, 0),
 				rollout.LastHealthReportAnnotation: "status: unhealthy\n" +

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -81,8 +81,6 @@ func TestUpdateService(t *testing.T) {
 		shouldErr      bool
 		nilService     bool
 	}{
-		// There is a revision with 100% of traffic different from stable and candidate.
-		// Make it the stable revision.
 		{
 			name: "stable revision based on traffic share",
 			traffic: []*run.TrafficTarget{
@@ -107,7 +105,6 @@ func TestUpdateService(t *testing.T) {
 				{LatestRevision: true, Tag: rollout.LatestTag},
 			},
 		},
-		// There's no a stable revision nor a revision handling 100% of traffic.
 		{
 			name: "no stable revision",
 			traffic: []*run.TrafficTarget{
@@ -117,7 +114,6 @@ func TestUpdateService(t *testing.T) {
 			lastReady:  "test-002",
 			nilService: true,
 		},
-		// Stable revision is the same as the latest revision. There's no candidate.
 		{
 			name: "same stable and latest revision",
 			traffic: []*run.TrafficTarget{
@@ -126,7 +122,6 @@ func TestUpdateService(t *testing.T) {
 			lastReady:  "test-001",
 			nilService: true,
 		},
-		// Candidate is new with non-existing previous candidate.
 		{
 			name: "new candidate and non-existing previous candidate",
 			traffic: []*run.TrafficTarget{
@@ -146,7 +141,6 @@ func TestUpdateService(t *testing.T) {
 				{LatestRevision: true, Tag: rollout.LatestTag},
 			},
 		},
-		// Candidate is the same as before (and healthy), keep rolling forward.
 		{
 			name: "keep rolling forward the same candidate",
 			traffic: []*run.TrafficTarget{
@@ -224,7 +218,6 @@ func TestUpdateService(t *testing.T) {
 				{LatestRevision: true, Tag: rollout.LatestTag},
 			},
 		},
-		// Candidate was handling 100% of traffic. It's now ready to become stable.
 		{
 			name: "candidate is ready to become stable",
 			traffic: []*run.TrafficTarget{
@@ -252,7 +245,6 @@ func TestUpdateService(t *testing.T) {
 				{LatestRevision: true, Tag: rollout.LatestTag},
 			},
 		},
-		// Candidate is unhealthy, rollback.
 		{
 			name: "unhealthy candidate, rollback",
 			traffic: []*run.TrafficTarget{
@@ -267,6 +259,7 @@ func TestUpdateService(t *testing.T) {
 			outAnnotations: map[string]string{
 				rollout.StableRevisionAnnotation:              "test-001",
 				rollout.CandidateRevisionAnnotation:           "test-002",
+				rollout.LastRolloutAnnotation:                 makeLastRolloutAnnotation(clockMock, 0),
 				rollout.LastFailedCandidateRevisionAnnotation: "test-002",
 				rollout.LastRolloutAnnotation:                 makeLastRolloutAnnotation(clockMock, 0),
 				rollout.LastHealthReportAnnotation: "status: unhealthy\n" +
@@ -280,7 +273,6 @@ func TestUpdateService(t *testing.T) {
 				{LatestRevision: true, Tag: rollout.LatestTag},
 			},
 		},
-		// Last ready revision is a previously failed candidate.
 		{
 			name: "latest ready is a failed candidate",
 			annotations: map[string]string{
@@ -293,7 +285,6 @@ func TestUpdateService(t *testing.T) {
 			lastReady:  "test-002",
 			nilService: true,
 		},
-		// Inconclusive diagnosis, do nothing.
 		{
 			name: "inconclusive diagnosis",
 			traffic: []*run.TrafficTarget{


### PR DESCRIPTION
This adds a new annotation containing the last time the traffic to the candidate was increased. Using the configuration for minimum time between roll forwards, it decides if it can continue rolling the candidate forward.