### PR TITLE
stackdriver: Return 0 if no request in interval

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -98,7 +98,7 @@ func init() {
 	flag.StringVar(&flStepsString, "steps", "5,20,50,80", "define steps in one flag separated by commas (e.g. 5,30,60)")
 	flag.IntVar(&flHealthOffsetMinute, "healthcheck-offset", 30, "use metrics from the last N minutes relative to current rollout process")
 	flag.DurationVar(&flTimeBeweenRollouts, "min-wait", 30*time.Minute, "minimum time to wait between rollout stages (in minutes), use 0 to disable")
-	flag.IntVar(&flMinRequestCount, "min-requests", 0, "expected minimum requests before determining candidate's health")
+	flag.IntVar(&flMinRequestCount, "min-requests", 100, "expected minimum requests before determining candidate's health")
 	flag.Float64Var(&flErrorRate, "max-error-rate", 1.0, "expected max server error rate (in percent)")
 	flag.Float64Var(&flLatencyP99, "latency-p99", 0, "expected max latency for 99th percentile of requests (set 0 to ignore)")
 	flag.Float64Var(&flLatencyP95, "latency-p95", 0, "expected max latency for 95th percentile of requests (set 0 to ignore)")

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -32,10 +32,12 @@ type Provider interface {
 
 	// Returns the request latency after applying the specified series aligner
 	// and cross series reducer. The result is in milliseconds.
+	// It returns 0 if no request was made during the interval.
 	Latency(ctx context.Context, offset time.Duration, alignReduceType AlignReduce) (float64, error)
 
 	// Gets all the server responses and calculates the error rate by performing
 	// the operation (5xx responses / all responses).
+	// It returns 0 if no request was made during the interval.
 	ErrorRate(ctx context.Context, offset time.Duration) (float64, error)
 }
 

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -82,6 +82,7 @@ func Diagnose(ctx context.Context, healthCriteria []config.Metric, actualValues 
 
 		// For unmet request count, return inconclusive and empty results.
 		if !isMet && criteria.Type == config.RequestCountMetricsCheck {
+			logger.Debug("unmet criterion")
 			diagnosis = Inconclusive
 			results = nil
 			break


### PR DESCRIPTION
When no request was made in the interval, Latency and ErrorRate returns errors that are propagated all the way to the main package. No requests shouldn't represent a metrics error.
