### PR TITLE
rollout: Update traffic in UpdateService

### DIFF
--- a/internal/rollout/rollout.go
+++ b/internal/rollout/rollout.go
@@ -132,7 +132,7 @@ func (r *Rollout) UpdateService(svc *run.Service) (*run.Service, error) {
 	// A new candidate does not have metrics yet, so it can't be diagnosed.
 	if isNewCandidate(svc, candidate) {
 		r.log.Debug("new candidate, assign some traffic")
-		svc = r.PrepareRollForward(svc, stable, candidate)
+		svc.Spec.Traffic = r.RollForwardTraffic(svc.Spec.Traffic, stable, candidate)
 		svc = r.updateAnnotations(svc, stable, candidate)
 		r.setHealthReportAnnotation(svc, "new candidate, no health report available yet")
 
@@ -146,17 +146,18 @@ func (r *Rollout) UpdateService(svc *run.Service) (*run.Service, error) {
 		return nil, errors.Wrapf(err, "failed to diagnose health for candidate %q", candidate)
 	}
 
-	svc, err = r.updateServiceBasedOnDiagnosis(svc, diagnosis.OverallResult, stable, candidate)
+	traffic, err := r.trafficBasedOnDiagnosis(svc, diagnosis.OverallResult, stable, candidate)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to update service after diagnosis")
+		return nil, errors.Wrap(err, "failed to configure traffic after diagnosis")
 	}
-	if svc == nil {
-		// If service was unchanged, nil is returned.
-		// TODO(gvso): This should go away once we start getting traffic config
-		// object from updateServiceBasedOnDiagnosis.
+	if traffic == nil {
+		// If traffic was unchanged, nil is returned.
+		// TODO(gvso): Do not return a nil service. Also update the annotations
+		// even if the traffic was unchanged.
 		return nil, nil
 	}
 
+	svc.Spec.Traffic = traffic
 	svc = r.updateAnnotations(svc, stable, candidate)
 	report := health.StringReport(r.strategy.HealthCriteria, diagnosis)
 	r.setHealthReportAnnotation(svc, report)
@@ -165,171 +166,10 @@ func (r *Rollout) UpdateService(svc *run.Service) (*run.Service, error) {
 	return svc, errors.Wrap(err, "failed to replace service")
 }
 
-// PrepareRollForward changes the traffic configuration of the service to
-// increase the traffic to the candidate.
-//
-// It creates a new traffic configuration for the service. It creates a new
-// traffic configuration for the candidate and stable revisions.
-// The method respects user-defined revision tags.
-func (r *Rollout) PrepareRollForward(svc *run.Service, stable, candidate string) *run.Service {
-	r.log.Debug("splitting traffic")
-
-	var traffic []*run.TrafficTarget
-	var stablePercent int64
-
-	candidateTraffic, promoteCandidateToStable := r.newCandidateTraffic(svc, candidate)
-	if promoteCandidateToStable {
-		r.promoteToStable = true
-		candidateTraffic.Tag = StableTag
-	} else {
-		// If candidate is not being promoted, also include traffic
-		// configuration for stable revision.
-		stablePercent = 100 - candidateTraffic.Percent
-		stableTraffic := newTrafficTarget(stable, stablePercent, StableTag)
-		traffic = append(traffic, stableTraffic)
-	}
-	traffic = append(traffic, candidateTraffic)
-	traffic = append(traffic, inheritRevisionTags(svc)...)
-
-	if r.promoteToStable {
-		r.log.Infof("will make candidate stable")
-	} else {
-		r.log.WithFields(logrus.Fields{
-			"stablePercent":    stablePercent,
-			"candidatePercent": candidateTraffic.Percent,
-		}).Info("set traffic split")
-	}
-
-	svc.Spec.Traffic = traffic
-	return svc
-}
-
-// PrepareRollback redirects all the traffic to the stable revision.
-func (r *Rollout) PrepareRollback(svc *run.Service, stable, candidate string) *run.Service {
-	traffic := []*run.TrafficTarget{
-		newTrafficTarget(stable, 100, StableTag),
-		newTrafficTarget(candidate, 0, CandidateTag),
-	}
-	traffic = append(traffic, inheritRevisionTags(svc)...)
-
-	svc.Spec.Traffic = traffic
-	return svc
-}
-
-// updateServiceBasedOnDiagnosis updates a service's traffic configuration
-// based on the diagnosis.
-// If service was unchanged, nil is returned.
-//
-// TODO (gvso): Refactor this and other methods to return only a traffic object.
-// Then, rename this to trafficBasedOnDiagnosis.
-// Also, move those traffic-config-related methods to traffic.go file.
-func (r *Rollout) updateServiceBasedOnDiagnosis(svc *run.Service, diagnosis health.DiagnosisResult, stable, candidate string) (*run.Service, error) {
-	switch diagnosis {
-	case health.Inconclusive:
-		r.log.Debug("health check inconclusive")
-		return nil, nil
-	case health.Healthy:
-		r.log.Debug("healthy candidate")
-		lastRollout := svc.Metadata.Annotations[LastRolloutAnnotation]
-		enoughTime, err := r.hasEnoughTimeElapsed(lastRollout, r.strategy.TimeBetweenRollouts)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not determine if roll out is allowed")
-		}
-		if !enoughTime {
-			r.log.WithField("lastRollout", lastRollout).Debug("no enough time elapsed since last roll out")
-			return nil, nil
-		}
-		r.log.Debug("rolling forward")
-		svc = r.PrepareRollForward(svc, stable, candidate)
-	case health.Unhealthy:
-		r.log.Info("unhealthy candidate, rollback")
-		r.shouldRollback = true
-		svc = r.PrepareRollback(svc, stable, candidate)
-	default:
-		return nil, errors.Errorf("invalid candidate's health diagnosis %v", diagnosis)
-	}
-
-	return svc, nil
-}
-
 // replaceService updates the service object in Cloud Run.
 func (r *Rollout) replaceService(svc *run.Service) error {
 	_, err := r.runClient.ReplaceService(r.project, r.serviceName, svc)
 	return errors.Wrapf(err, "could not update service %q", r.serviceName)
-}
-
-// newCandidateTraffic returns the next candidate's traffic configuration.
-//
-// It also checks if the candidate should be promoted to stable in the next
-// update and returns a boolean about that.
-func (r *Rollout) newCandidateTraffic(svc *run.Service, candidate string) (*run.TrafficTarget, bool) {
-	var promoteToStable bool
-	var candidatePercent int64
-	candidateTarget := r.currentCandidateTraffic(svc, candidate)
-	if candidateTarget == nil {
-		candidatePercent = r.strategy.Steps[0]
-	} else {
-		candidatePercent = r.nextCandidateTraffic(candidateTarget.Percent)
-
-		// If the traffic share did not change, candidate already handled 100%
-		// and is now ready to become stable.
-		if candidatePercent == candidateTarget.Percent {
-			promoteToStable = true
-		}
-	}
-
-	candidateTarget = newTrafficTarget(candidate, candidatePercent, CandidateTag)
-
-	return candidateTarget, promoteToStable
-}
-
-// inheritRevisionTags returns the tags that must be conserved.
-func inheritRevisionTags(svc *run.Service) []*run.TrafficTarget {
-	traffic := []*run.TrafficTarget{
-		// Always assign latest tag to the latest revision.
-		{LatestRevision: true, Tag: LatestTag},
-	}
-	// Respect tags manually introduced by the user (e.g. UI/gcloud).
-	customTags := userDefinedTrafficTags(svc)
-	traffic = append(traffic, customTags...)
-	return traffic
-}
-
-// userDefinedTrafficTags returns the traffic configurations that include tags
-// that were defined by the user (e.g. UI/gcloud).
-func userDefinedTrafficTags(svc *run.Service) []*run.TrafficTarget {
-	var traffic []*run.TrafficTarget
-	for _, target := range svc.Spec.Traffic {
-		if target.Tag != "" && !target.LatestRevision &&
-			target.Tag != StableTag && target.Tag != CandidateTag {
-
-			traffic = append(traffic, target)
-		}
-	}
-
-	return traffic
-}
-
-// currentCandidateTraffic returns the traffic configuration for the candidate.
-func (r *Rollout) currentCandidateTraffic(svc *run.Service, candidate string) *run.TrafficTarget {
-	for _, target := range svc.Status.Traffic {
-		if target.RevisionName == candidate && target.Percent > 0 {
-			return target
-		}
-	}
-
-	return nil
-}
-
-// nextCandidateTraffic calculates the next traffic share for the candidate.
-func (r *Rollout) nextCandidateTraffic(current int64) int64 {
-	for _, step := range r.strategy.Steps {
-		if step > current {
-			return step
-		}
-	}
-
-	return 100
 }
 
 // updateAnnotations updates the annotations to keep some state about the rollout.
@@ -382,30 +222,4 @@ func (r *Rollout) diagnoseCandidate(candidate string, healthCriteria []config.He
 	r.log.Debug("diagnosing candidate's health")
 	d, err = health.Diagnose(ctx, healthCriteria, metricsValues)
 	return d, errors.Wrap(err, "failed to diagnose candidate's health")
-}
-
-// hasEnoughTimeElapsed determines if enough time has elapsed since last
-// rollout.
-//
-// TODO: what if lastRolloutStr is always invalid?
-func (r *Rollout) hasEnoughTimeElapsed(lastRolloutStr string, timeBetweenRollouts time.Duration) (bool, error) {
-	if lastRolloutStr == "" {
-		return false, errors.Errorf("%s annotation is missing", LastRolloutAnnotation)
-	}
-	lastRollout, err := time.Parse(time.RFC3339, lastRolloutStr)
-	if err != nil {
-		return false, errors.Wrap(err, "failed to parse last roll out time")
-	}
-
-	currentTime := r.time.Now()
-	return currentTime.Sub(lastRollout) >= timeBetweenRollouts, nil
-}
-
-// newTrafficTarget returns a new traffic target instance.
-func newTrafficTarget(revision string, percent int64, tag string) *run.TrafficTarget {
-	return &run.TrafficTarget{
-		RevisionName: revision,
-		Percent:      percent,
-		Tag:          tag,
-	}
 }

--- a/internal/rollout/rollout.go
+++ b/internal/rollout/rollout.go
@@ -132,7 +132,7 @@ func (r *Rollout) UpdateService(svc *run.Service) (*run.Service, error) {
 	// A new candidate does not have metrics yet, so it can't be diagnosed.
 	if isNewCandidate(svc, candidate) {
 		r.log.Debug("new candidate, assign some traffic")
-		svc.Spec.Traffic = r.RollForwardTraffic(svc.Spec.Traffic, stable, candidate)
+		svc.Spec.Traffic = r.rollForwardTraffic(svc.Spec.Traffic, stable, candidate)
 		svc = r.updateAnnotations(svc, stable, candidate)
 		r.setHealthReportAnnotation(svc, "new candidate, no health report available yet")
 
@@ -146,7 +146,7 @@ func (r *Rollout) UpdateService(svc *run.Service) (*run.Service, error) {
 		return nil, errors.Wrapf(err, "failed to diagnose health for candidate %q", candidate)
 	}
 
-	traffic, err := r.trafficBasedOnDiagnosis(svc, diagnosis.OverallResult, stable, candidate)
+	traffic, err := r.determineTraffic(svc, diagnosis.OverallResult, stable, candidate)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to configure traffic after diagnosis")
 	}

--- a/internal/rollout/rollout_test.go
+++ b/internal/rollout/rollout_test.go
@@ -8,16 +8,9 @@ import (
 
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/config"
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/metrics"
-<<<<<<< HEAD:internal/rollout/rollout_test.go
-	metricsMocker "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/metrics/mock"
-	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/rollout"
-	runMocker "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/run/mock"
-=======
 	metricsmock "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/metrics/mock"
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/rollout"
 	runmock "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/run/mock"
-	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/config"
-	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/rollout"
->>>>>>> rollout: Update traffic in UpdateService:pkg/rollout/rollout_test.go
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"

--- a/internal/rollout/rollout_test.go
+++ b/internal/rollout/rollout_test.go
@@ -2,6 +2,7 @@ package rollout_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 

--- a/internal/rollout/rollout_test.go
+++ b/internal/rollout/rollout_test.go
@@ -2,15 +2,21 @@ package rollout_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/config"
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/metrics"
+<<<<<<< HEAD:internal/rollout/rollout_test.go
 	metricsMocker "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/metrics/mock"
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/rollout"
 	runMocker "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/run/mock"
+=======
+	metricsmock "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/metrics/mock"
+	runmock "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/run/mock"
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/config"
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/rollout"
+>>>>>>> rollout: Update traffic in UpdateService:pkg/rollout/rollout_test.go
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -46,9 +52,9 @@ func makeLastRolloutAnnotation(clock clockwork.Clock, offsetFromNowMinute int) s
 }
 
 func TestUpdateService(t *testing.T) {
-	runclient := &runMocker.RunAPI{}
+	runclient := &runmock.RunAPI{}
 	clockMock := clockwork.NewFakeClock()
-	metricsMock := &metricsMocker.Metrics{}
+	metricsMock := &metricsmock.Metrics{}
 	metricsMock.RequestCountFn = func(ctx context.Context, offset time.Duration) (int64, error) {
 		return 1000, nil
 	}
@@ -347,160 +353,4 @@ func TestUpdateService(t *testing.T) {
 		})
 
 	}
-}
-
-func TestPrepareRollForward(t *testing.T) {
-	runclient := &runMocker.RunAPI{}
-	metricsMock := &metricsMocker.Metrics{}
-	strategy := config.Strategy{
-		Steps: []int64{5, 30, 60},
-	}
-
-	var tests = []struct {
-		name      string
-		stable    string
-		candidate string
-		traffic   []*run.TrafficTarget
-		expected  []*run.TrafficTarget
-	}{
-		// There's a new candidate. Restart rollout process
-		{
-			name:      "new candidate, restart rollout",
-			stable:    "test-001",
-			candidate: "test-003",
-			traffic: []*run.TrafficTarget{
-				{RevisionName: "test-001", Percent: 50},
-				{RevisionName: "test-001", Tag: "tag1"},
-				{RevisionName: "test-002", Percent: 50, Tag: rollout.CandidateTag},
-				{RevisionName: "test-002", Tag: "tag2"},
-				{LatestRevision: true, Tag: rollout.LatestTag},
-			},
-			expected: []*run.TrafficTarget{
-				{RevisionName: "test-001", Percent: 95, Tag: rollout.StableTag},
-				{RevisionName: "test-003", Percent: 5, Tag: rollout.CandidateTag},
-				{LatestRevision: true, Tag: rollout.LatestTag},
-				{RevisionName: "test-001", Tag: "tag1"},
-				{RevisionName: "test-002", Tag: "tag2"},
-			},
-		},
-		// Candidate is the same. Continue rolling forward.
-		{
-			name:      "continue rolling out candidate",
-			stable:    "test-001",
-			candidate: "test-003",
-			traffic: []*run.TrafficTarget{
-				{RevisionName: "test-001", Percent: 70, Tag: rollout.StableTag},
-				{RevisionName: "test-002", Tag: "tag1"},
-				{RevisionName: "test-003", Percent: 30, Tag: rollout.CandidateTag},
-				{RevisionName: "test-003", Tag: "tag2"},
-				{LatestRevision: true, Tag: rollout.LatestTag},
-			},
-			expected: []*run.TrafficTarget{
-				{RevisionName: "test-001", Percent: 40, Tag: rollout.StableTag},
-				{RevisionName: "test-003", Percent: 60, Tag: rollout.CandidateTag},
-				{LatestRevision: true, Tag: rollout.LatestTag},
-				{RevisionName: "test-002", Tag: "tag1"},
-				{RevisionName: "test-003", Tag: "tag2"},
-			},
-		},
-		// Candidate is the same. Continue rolling forward to 100%.
-		{
-			name:      "roll out to 100%",
-			stable:    "test-001",
-			candidate: "test-003",
-			traffic: []*run.TrafficTarget{
-				{RevisionName: "test-001", Percent: 40, Tag: rollout.StableTag},
-				{RevisionName: "test-002", Tag: "tag1"},
-				{RevisionName: "test-003", Percent: 60, Tag: rollout.CandidateTag},
-				{RevisionName: "test-003", Tag: "tag2"},
-			},
-			expected: []*run.TrafficTarget{
-				{RevisionName: "test-001", Percent: 0, Tag: rollout.StableTag},
-				{RevisionName: "test-003", Percent: 100, Tag: rollout.CandidateTag},
-				{LatestRevision: true, Tag: rollout.LatestTag},
-				{RevisionName: "test-002", Tag: "tag1"},
-				{RevisionName: "test-003", Tag: "tag2"},
-			},
-		},
-		// Candidate has proven able to handle 100%, make it stable.
-		{
-			name:      "make candidate stable",
-			stable:    "test-001",
-			candidate: "test-003",
-			traffic: []*run.TrafficTarget{
-				{RevisionName: "test-001", Percent: 0, Tag: rollout.StableTag},
-				{RevisionName: "test-002", Tag: "tag1"},
-				{RevisionName: "test-003", Percent: 100, Tag: rollout.CandidateTag},
-				{RevisionName: "test-003", Tag: "tag2"},
-				{LatestRevision: true, Tag: rollout.LatestTag},
-			},
-			expected: []*run.TrafficTarget{
-				{RevisionName: "test-003", Percent: 100, Tag: rollout.StableTag},
-				{LatestRevision: true, Tag: rollout.LatestTag},
-				{RevisionName: "test-002", Tag: "tag1"},
-				{RevisionName: "test-003", Tag: "tag2"},
-			},
-		},
-		// Two targets for the same stable and candidate revisions.
-		{
-			name:      "two targets for same revision",
-			stable:    "test-001",
-			candidate: "test-003",
-			traffic: []*run.TrafficTarget{
-				{RevisionName: "test-001", Percent: 70},
-				{RevisionName: "test-001", Tag: rollout.StableTag},
-				{RevisionName: "test-002", Tag: "tag1"},
-				{RevisionName: "test-003", Percent: 30},
-				{RevisionName: "test-003", Tag: rollout.CandidateTag},
-				{LatestRevision: true, Tag: rollout.LatestTag},
-			},
-			expected: []*run.TrafficTarget{
-				{RevisionName: "test-001", Percent: 40, Tag: rollout.StableTag},
-				{RevisionName: "test-003", Percent: 60, Tag: rollout.CandidateTag},
-				{LatestRevision: true, Tag: rollout.LatestTag},
-				{RevisionName: "test-002", Tag: "tag1"},
-			},
-		},
-	}
-
-	for _, test := range tests {
-		opts := &ServiceOpts{
-			Traffic: test.traffic,
-		}
-		svc := generateService(opts)
-		svcRecord := &rollout.ServiceRecord{Service: svc}
-
-		r := rollout.New(context.TODO(), metricsMock, svcRecord, strategy).WithClient(runclient)
-
-		t.Run(test.name, func(tt *testing.T) {
-			svc = r.PrepareRollForward(svc, test.stable, test.candidate)
-			assert.Equal(tt, test.expected, svc.Spec.Traffic)
-		})
-	}
-}
-
-func TestPrepareRollback(t *testing.T) {
-	metricsMock := &metricsMocker.Metrics{}
-
-	stable := "test-001"
-	candidate := "test-003"
-	traffic := []*run.TrafficTarget{
-		{RevisionName: "test-001", Percent: 40, Tag: rollout.StableTag},
-		{RevisionName: "test-002", Tag: "tag1"},
-		{RevisionName: "test-003", Percent: 60, Tag: rollout.CandidateTag},
-		{RevisionName: "test-003", Tag: "tag2"},
-	}
-	expectedTraffic := []*run.TrafficTarget{
-		{RevisionName: "test-001", Percent: 100, Tag: rollout.StableTag},
-		{RevisionName: "test-003", Percent: 0, Tag: rollout.CandidateTag},
-		{LatestRevision: true, Tag: rollout.LatestTag},
-		{RevisionName: "test-002", Tag: "tag1"},
-		{RevisionName: "test-003", Tag: "tag2"},
-	}
-	svc := generateService(&ServiceOpts{Traffic: traffic})
-	svcRecord := &rollout.ServiceRecord{Service: svc}
-
-	r := rollout.New(context.TODO(), metricsMock, svcRecord, config.Strategy{})
-	svc = r.PrepareRollback(svc, stable, candidate)
-	assert.Equal(t, expectedTraffic, svc.Spec.Traffic)
 }

--- a/internal/rollout/traffic.go
+++ b/internal/rollout/traffic.go
@@ -1,0 +1,184 @@
+package rollout
+
+import (
+	"time"
+
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/health"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/api/run/v1"
+)
+
+// trafficBasedOnDiagnosis updates a service's traffic configuration
+// based on the diagnosis.
+// If traffic should not changed, nil is returned.
+func (r *Rollout) trafficBasedOnDiagnosis(svc *run.Service, diagnosis health.DiagnosisResult, stable, candidate string) ([]*run.TrafficTarget, error) {
+	switch diagnosis {
+	case health.Inconclusive:
+		r.log.Debug("health check inconclusive")
+		return nil, nil
+	case health.Healthy:
+		r.log.Debug("healthy candidate")
+		lastRollout := svc.Metadata.Annotations[LastRolloutAnnotation]
+		enoughTime, err := r.hasEnoughTimeElapsed(lastRollout, r.strategy.TimeBetweenRollouts)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not determine if roll out is allowed")
+		}
+		if !enoughTime {
+			r.log.WithField("lastRollout", lastRollout).Debug("no enough time elapsed since last roll out")
+			return nil, nil
+		}
+		r.log.Debug("rolling forward")
+		return r.RollForwardTraffic(svc.Spec.Traffic, stable, candidate), nil
+	case health.Unhealthy:
+		r.log.Info("unhealthy candidate, rollback")
+		r.shouldRollback = true
+		return r.RollbackTraffic(svc.Spec.Traffic, stable, candidate), nil
+	default:
+		return nil, errors.Errorf("invalid candidate's health diagnosis %v", diagnosis)
+	}
+}
+
+// RollForwardTraffic updates the traffic configuration to increase the traffic
+// to the candidate.
+//
+// It creates new traffic configurations for the candidate and stable revisions
+// and respects user-defined revision tags.
+func (r *Rollout) RollForwardTraffic(traffic []*run.TrafficTarget, stable, candidate string) []*run.TrafficTarget {
+	r.log.Debug("splitting traffic")
+
+	var newTraffic []*run.TrafficTarget
+	var stablePercent int64
+
+	candidateTraffic, promoteCandidateToStable := r.newCandidateTraffic(traffic, candidate)
+	if promoteCandidateToStable {
+		r.promoteToStable = true
+		candidateTraffic.Tag = StableTag
+	} else {
+		// If candidate is not being promoted, also include traffic
+		// configuration for stable revision.
+		stablePercent = 100 - candidateTraffic.Percent
+		stableTraffic := newTrafficTarget(stable, stablePercent, StableTag)
+		newTraffic = append(newTraffic, stableTraffic)
+	}
+	newTraffic = append(newTraffic, candidateTraffic)
+	newTraffic = append(newTraffic, inheritRevisionTags(traffic)...)
+
+	if r.promoteToStable {
+		r.log.Infof("will make candidate stable")
+	} else {
+		r.log.WithFields(logrus.Fields{
+			"stablePercent":    stablePercent,
+			"candidatePercent": candidateTraffic.Percent,
+		}).Info("set traffic split")
+	}
+
+	return newTraffic
+}
+
+// RollbackTraffic redirects all the traffic to the stable revision.
+func (r *Rollout) RollbackTraffic(traffic []*run.TrafficTarget, stable, candidate string) []*run.TrafficTarget {
+	newTraffic := []*run.TrafficTarget{
+		newTrafficTarget(stable, 100, StableTag),
+		newTrafficTarget(candidate, 0, CandidateTag),
+	}
+	return append(newTraffic, inheritRevisionTags(traffic)...)
+}
+
+// newCandidateTraffic returns the next candidate's traffic configuration.
+//
+// It also checks if the candidate should be promoted to stable in the next
+// update and returns a boolean about that.
+func (r *Rollout) newCandidateTraffic(traffic []*run.TrafficTarget, candidate string) (*run.TrafficTarget, bool) {
+	var promoteToStable bool
+	var candidatePercent int64
+	candidateTarget := r.currentCandidateTraffic(traffic, candidate)
+	if candidateTarget == nil {
+		candidatePercent = r.strategy.Steps[0]
+	} else {
+		candidatePercent = r.nextCandidateTraffic(candidateTarget.Percent)
+
+		// If the traffic share did not change, candidate already handled 100%
+		// and is now ready to become stable.
+		if candidatePercent == candidateTarget.Percent {
+			promoteToStable = true
+		}
+	}
+
+	candidateTarget = newTrafficTarget(candidate, candidatePercent, CandidateTag)
+	return candidateTarget, promoteToStable
+}
+
+// inheritRevisionTags returns the tags that must be conserved.
+func inheritRevisionTags(traffic []*run.TrafficTarget) []*run.TrafficTarget {
+	newTraffic := []*run.TrafficTarget{
+		// Always assign latest tag to the latest revision.
+		{LatestRevision: true, Tag: LatestTag},
+	}
+	// Respect tags manually introduced by the user (e.g. UI/gcloud).
+	customTags := userDefinedTrafficTags(traffic)
+	return append(newTraffic, customTags...)
+}
+
+// userDefinedTrafficTags returns the traffic configurations that include tags
+// that were defined by the user (e.g. UI/gcloud).
+func userDefinedTrafficTags(traffic []*run.TrafficTarget) []*run.TrafficTarget {
+	var newTraffic []*run.TrafficTarget
+	for _, target := range traffic {
+		if target.Tag != "" && !target.LatestRevision &&
+			target.Tag != StableTag && target.Tag != CandidateTag {
+
+			newTraffic = append(newTraffic, target)
+		}
+	}
+
+	return newTraffic
+}
+
+// currentCandidateTraffic returns the traffic configuration for the candidate.
+func (r *Rollout) currentCandidateTraffic(traffic []*run.TrafficTarget, candidate string) *run.TrafficTarget {
+	for _, target := range traffic {
+		if target.RevisionName == candidate && target.Percent > 0 {
+			return target
+		}
+	}
+
+	return nil
+}
+
+// nextCandidateTraffic calculates the next traffic share for the candidate.
+func (r *Rollout) nextCandidateTraffic(current int64) int64 {
+	for _, step := range r.strategy.Steps {
+		if step > current {
+			return step
+		}
+	}
+
+	return 100
+}
+
+// newTrafficTarget returns a new traffic target instance.
+func newTrafficTarget(revision string, percent int64, tag string) *run.TrafficTarget {
+	return &run.TrafficTarget{
+		RevisionName: revision,
+		Percent:      percent,
+		Tag:          tag,
+	}
+}
+
+// hasEnoughTimeElapsed determines if enough time has elapsed since last
+// rollout.
+//
+// TODO: what if lastRolloutStr is always invalid?
+func (r *Rollout) hasEnoughTimeElapsed(lastRolloutStr string, timeBetweenRollouts time.Duration) (bool, error) {
+	if lastRolloutStr == "" {
+		return false, errors.Errorf("%s annotation is missing", LastRolloutAnnotation)
+	}
+	lastRollout, err := time.Parse(time.RFC3339, lastRolloutStr)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to parse last roll out time")
+	}
+
+	currentTime := r.time.Now()
+	return currentTime.Sub(lastRollout) >= timeBetweenRollouts, nil
+}

--- a/internal/rollout/traffic.go
+++ b/internal/rollout/traffic.go
@@ -27,7 +27,7 @@ func (r *Rollout) determineTraffic(svc *run.Service, diagnosis health.DiagnosisR
 			r.log.WithField("lastRollout", lastRollout).Debug("no enough time elapsed since last roll out")
 			return nil, nil
 		}
-		r.log.Debug("rolling forward")
+		r.log.Info("rolling forward")
 		return r.rollForwardTraffic(svc.Spec.Traffic, stable, candidate), nil
 	case health.Unhealthy:
 		r.log.Info("unhealthy candidate, rollback")
@@ -44,8 +44,6 @@ func (r *Rollout) determineTraffic(svc *run.Service, diagnosis health.DiagnosisR
 // It creates new traffic configurations for the candidate and stable revisions
 // and respects user-defined revision tags.
 func (r *Rollout) rollForwardTraffic(traffic []*run.TrafficTarget, stable, candidate string) []*run.TrafficTarget {
-	r.log.Debug("splitting traffic")
-
 	var newTraffic []*run.TrafficTarget
 	var stablePercent int64
 

--- a/internal/rollout/traffic.go
+++ b/internal/rollout/traffic.go
@@ -3,7 +3,7 @@ package rollout
 import (
 	"time"
 
-	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/health"
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/health"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/run/v1"

--- a/internal/rollout/traffic_test.go
+++ b/internal/rollout/traffic_test.go
@@ -1,0 +1,164 @@
+package rollout_test
+
+import (
+	"context"
+	"testing"
+
+	metricsmock "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/metrics/mock"
+	runmock "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/run/mock"
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/config"
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/rollout"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/run/v1"
+)
+
+func TestRollForwardTraffic(t *testing.T) {
+	runclient := &runmock.RunAPI{}
+	metricsMock := &metricsmock.Metrics{}
+	strategy := config.Strategy{
+		Steps: []int64{5, 30, 60},
+	}
+
+	var tests = []struct {
+		name      string
+		stable    string
+		candidate string
+		traffic   []*run.TrafficTarget
+		expected  []*run.TrafficTarget
+	}{
+		{
+			name:      "new candidate, restart rollout",
+			stable:    "test-001",
+			candidate: "test-003",
+			traffic: []*run.TrafficTarget{
+				{RevisionName: "test-001", Percent: 50},
+				{RevisionName: "test-001", Tag: "tag1"},
+				{RevisionName: "test-002", Percent: 50, Tag: rollout.CandidateTag},
+				{RevisionName: "test-002", Tag: "tag2"},
+				{LatestRevision: true, Tag: rollout.LatestTag},
+			},
+			expected: []*run.TrafficTarget{
+				{RevisionName: "test-001", Percent: 95, Tag: rollout.StableTag},
+				{RevisionName: "test-003", Percent: 5, Tag: rollout.CandidateTag},
+				{LatestRevision: true, Tag: rollout.LatestTag},
+				{RevisionName: "test-001", Tag: "tag1"},
+				{RevisionName: "test-002", Tag: "tag2"},
+			},
+		},
+		{
+			name:      "continue rolling out candidate",
+			stable:    "test-001",
+			candidate: "test-003",
+			traffic: []*run.TrafficTarget{
+				{RevisionName: "test-001", Percent: 70, Tag: rollout.StableTag},
+				{RevisionName: "test-002", Tag: "tag1"},
+				{RevisionName: "test-003", Percent: 30, Tag: rollout.CandidateTag},
+				{RevisionName: "test-003", Tag: "tag2"},
+				{LatestRevision: true, Tag: rollout.LatestTag},
+			},
+			expected: []*run.TrafficTarget{
+				{RevisionName: "test-001", Percent: 40, Tag: rollout.StableTag},
+				{RevisionName: "test-003", Percent: 60, Tag: rollout.CandidateTag},
+				{LatestRevision: true, Tag: rollout.LatestTag},
+				{RevisionName: "test-002", Tag: "tag1"},
+				{RevisionName: "test-003", Tag: "tag2"},
+			},
+		},
+		{
+			name:      "roll out to 100%",
+			stable:    "test-001",
+			candidate: "test-003",
+			traffic: []*run.TrafficTarget{
+				{RevisionName: "test-001", Percent: 40, Tag: rollout.StableTag},
+				{RevisionName: "test-002", Tag: "tag1"},
+				{RevisionName: "test-003", Percent: 60, Tag: rollout.CandidateTag},
+				{RevisionName: "test-003", Tag: "tag2"},
+			},
+			expected: []*run.TrafficTarget{
+				{RevisionName: "test-001", Percent: 0, Tag: rollout.StableTag},
+				{RevisionName: "test-003", Percent: 100, Tag: rollout.CandidateTag},
+				{LatestRevision: true, Tag: rollout.LatestTag},
+				{RevisionName: "test-002", Tag: "tag1"},
+				{RevisionName: "test-003", Tag: "tag2"},
+			},
+		},
+		{
+			name:      "make candidate stable",
+			stable:    "test-001",
+			candidate: "test-003",
+			traffic: []*run.TrafficTarget{
+				{RevisionName: "test-001", Percent: 0, Tag: rollout.StableTag},
+				{RevisionName: "test-002", Tag: "tag1"},
+				{RevisionName: "test-003", Percent: 100, Tag: rollout.CandidateTag},
+				{RevisionName: "test-003", Tag: "tag2"},
+				{LatestRevision: true, Tag: rollout.LatestTag},
+			},
+			expected: []*run.TrafficTarget{
+				{RevisionName: "test-003", Percent: 100, Tag: rollout.StableTag},
+				{LatestRevision: true, Tag: rollout.LatestTag},
+				{RevisionName: "test-002", Tag: "tag1"},
+				{RevisionName: "test-003", Tag: "tag2"},
+			},
+		},
+		{
+			name:      "two targets for same revision",
+			stable:    "test-001",
+			candidate: "test-003",
+			traffic: []*run.TrafficTarget{
+				{RevisionName: "test-001", Percent: 70},
+				{RevisionName: "test-001", Tag: rollout.StableTag},
+				{RevisionName: "test-002", Tag: "tag1"},
+				{RevisionName: "test-003", Percent: 30},
+				{RevisionName: "test-003", Tag: rollout.CandidateTag},
+				{LatestRevision: true, Tag: rollout.LatestTag},
+			},
+			expected: []*run.TrafficTarget{
+				{RevisionName: "test-001", Percent: 40, Tag: rollout.StableTag},
+				{RevisionName: "test-003", Percent: 60, Tag: rollout.CandidateTag},
+				{LatestRevision: true, Tag: rollout.LatestTag},
+				{RevisionName: "test-002", Tag: "tag1"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		opts := &ServiceOpts{
+			Traffic: test.traffic,
+		}
+		svc := generateService(opts)
+		svcRecord := &rollout.ServiceRecord{Service: svc}
+
+		r := rollout.New(context.TODO(), metricsMock, svcRecord, strategy).WithClient(runclient)
+
+		t.Run(test.name, func(tt *testing.T) {
+			traffic := r.RollForwardTraffic(svc.Spec.Traffic, test.stable, test.candidate)
+			assert.Equal(tt, test.expected, traffic)
+		})
+	}
+}
+
+func TestRollbackTraffic(t *testing.T) {
+	metricsMock := &metricsmock.Metrics{}
+
+	stable := "test-001"
+	candidate := "test-003"
+	traffic := []*run.TrafficTarget{
+		{RevisionName: "test-001", Percent: 40, Tag: rollout.StableTag},
+		{RevisionName: "test-002", Tag: "tag1"},
+		{RevisionName: "test-003", Percent: 60, Tag: rollout.CandidateTag},
+		{RevisionName: "test-003", Tag: "tag2"},
+	}
+	expectedTraffic := []*run.TrafficTarget{
+		{RevisionName: "test-001", Percent: 100, Tag: rollout.StableTag},
+		{RevisionName: "test-003", Percent: 0, Tag: rollout.CandidateTag},
+		{LatestRevision: true, Tag: rollout.LatestTag},
+		{RevisionName: "test-002", Tag: "tag1"},
+		{RevisionName: "test-003", Tag: "tag2"},
+	}
+	svc := generateService(&ServiceOpts{Traffic: traffic})
+	svcRecord := &rollout.ServiceRecord{Service: svc}
+
+	r := rollout.New(context.TODO(), metricsMock, svcRecord, config.Strategy{})
+	traffic = r.RollbackTraffic(svc.Spec.Traffic, stable, candidate)
+	assert.Equal(t, expectedTraffic, traffic)
+}

--- a/internal/rollout/traffic_test.go
+++ b/internal/rollout/traffic_test.go
@@ -1,4 +1,4 @@
-package rollout_test
+package rollout
 
 import (
 	"context"
@@ -7,7 +7,6 @@ import (
 	metricsmock "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/metrics/mock"
 	runmock "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/run/mock"
 	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/config"
-	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/rollout"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/run/v1"
 )
@@ -33,14 +32,14 @@ func TestRollForwardTraffic(t *testing.T) {
 			traffic: []*run.TrafficTarget{
 				{RevisionName: "test-001", Percent: 50},
 				{RevisionName: "test-001", Tag: "tag1"},
-				{RevisionName: "test-002", Percent: 50, Tag: rollout.CandidateTag},
+				{RevisionName: "test-002", Percent: 50, Tag: CandidateTag},
 				{RevisionName: "test-002", Tag: "tag2"},
-				{LatestRevision: true, Tag: rollout.LatestTag},
+				{LatestRevision: true, Tag: LatestTag},
 			},
 			expected: []*run.TrafficTarget{
-				{RevisionName: "test-001", Percent: 95, Tag: rollout.StableTag},
-				{RevisionName: "test-003", Percent: 5, Tag: rollout.CandidateTag},
-				{LatestRevision: true, Tag: rollout.LatestTag},
+				{RevisionName: "test-001", Percent: 95, Tag: StableTag},
+				{RevisionName: "test-003", Percent: 5, Tag: CandidateTag},
+				{LatestRevision: true, Tag: LatestTag},
 				{RevisionName: "test-001", Tag: "tag1"},
 				{RevisionName: "test-002", Tag: "tag2"},
 			},
@@ -50,16 +49,16 @@ func TestRollForwardTraffic(t *testing.T) {
 			stable:    "test-001",
 			candidate: "test-003",
 			traffic: []*run.TrafficTarget{
-				{RevisionName: "test-001", Percent: 70, Tag: rollout.StableTag},
+				{RevisionName: "test-001", Percent: 70, Tag: StableTag},
 				{RevisionName: "test-002", Tag: "tag1"},
-				{RevisionName: "test-003", Percent: 30, Tag: rollout.CandidateTag},
+				{RevisionName: "test-003", Percent: 30, Tag: CandidateTag},
 				{RevisionName: "test-003", Tag: "tag2"},
-				{LatestRevision: true, Tag: rollout.LatestTag},
+				{LatestRevision: true, Tag: LatestTag},
 			},
 			expected: []*run.TrafficTarget{
-				{RevisionName: "test-001", Percent: 40, Tag: rollout.StableTag},
-				{RevisionName: "test-003", Percent: 60, Tag: rollout.CandidateTag},
-				{LatestRevision: true, Tag: rollout.LatestTag},
+				{RevisionName: "test-001", Percent: 40, Tag: StableTag},
+				{RevisionName: "test-003", Percent: 60, Tag: CandidateTag},
+				{LatestRevision: true, Tag: LatestTag},
 				{RevisionName: "test-002", Tag: "tag1"},
 				{RevisionName: "test-003", Tag: "tag2"},
 			},
@@ -69,15 +68,15 @@ func TestRollForwardTraffic(t *testing.T) {
 			stable:    "test-001",
 			candidate: "test-003",
 			traffic: []*run.TrafficTarget{
-				{RevisionName: "test-001", Percent: 40, Tag: rollout.StableTag},
+				{RevisionName: "test-001", Percent: 40, Tag: StableTag},
 				{RevisionName: "test-002", Tag: "tag1"},
-				{RevisionName: "test-003", Percent: 60, Tag: rollout.CandidateTag},
+				{RevisionName: "test-003", Percent: 60, Tag: CandidateTag},
 				{RevisionName: "test-003", Tag: "tag2"},
 			},
 			expected: []*run.TrafficTarget{
-				{RevisionName: "test-001", Percent: 0, Tag: rollout.StableTag},
-				{RevisionName: "test-003", Percent: 100, Tag: rollout.CandidateTag},
-				{LatestRevision: true, Tag: rollout.LatestTag},
+				{RevisionName: "test-001", Percent: 0, Tag: StableTag},
+				{RevisionName: "test-003", Percent: 100, Tag: CandidateTag},
+				{LatestRevision: true, Tag: LatestTag},
 				{RevisionName: "test-002", Tag: "tag1"},
 				{RevisionName: "test-003", Tag: "tag2"},
 			},
@@ -87,15 +86,15 @@ func TestRollForwardTraffic(t *testing.T) {
 			stable:    "test-001",
 			candidate: "test-003",
 			traffic: []*run.TrafficTarget{
-				{RevisionName: "test-001", Percent: 0, Tag: rollout.StableTag},
+				{RevisionName: "test-001", Percent: 0, Tag: StableTag},
 				{RevisionName: "test-002", Tag: "tag1"},
-				{RevisionName: "test-003", Percent: 100, Tag: rollout.CandidateTag},
+				{RevisionName: "test-003", Percent: 100, Tag: CandidateTag},
 				{RevisionName: "test-003", Tag: "tag2"},
-				{LatestRevision: true, Tag: rollout.LatestTag},
+				{LatestRevision: true, Tag: LatestTag},
 			},
 			expected: []*run.TrafficTarget{
-				{RevisionName: "test-003", Percent: 100, Tag: rollout.StableTag},
-				{LatestRevision: true, Tag: rollout.LatestTag},
+				{RevisionName: "test-003", Percent: 100, Tag: StableTag},
+				{LatestRevision: true, Tag: LatestTag},
 				{RevisionName: "test-002", Tag: "tag1"},
 				{RevisionName: "test-003", Tag: "tag2"},
 			},
@@ -106,32 +105,34 @@ func TestRollForwardTraffic(t *testing.T) {
 			candidate: "test-003",
 			traffic: []*run.TrafficTarget{
 				{RevisionName: "test-001", Percent: 70},
-				{RevisionName: "test-001", Tag: rollout.StableTag},
+				{RevisionName: "test-001", Tag: StableTag},
 				{RevisionName: "test-002", Tag: "tag1"},
 				{RevisionName: "test-003", Percent: 30},
-				{RevisionName: "test-003", Tag: rollout.CandidateTag},
-				{LatestRevision: true, Tag: rollout.LatestTag},
+				{RevisionName: "test-003", Tag: CandidateTag},
+				{LatestRevision: true, Tag: LatestTag},
 			},
 			expected: []*run.TrafficTarget{
-				{RevisionName: "test-001", Percent: 40, Tag: rollout.StableTag},
-				{RevisionName: "test-003", Percent: 60, Tag: rollout.CandidateTag},
-				{LatestRevision: true, Tag: rollout.LatestTag},
+				{RevisionName: "test-001", Percent: 40, Tag: StableTag},
+				{RevisionName: "test-003", Percent: 60, Tag: CandidateTag},
+				{LatestRevision: true, Tag: LatestTag},
 				{RevisionName: "test-002", Tag: "tag1"},
 			},
 		},
 	}
 
 	for _, test := range tests {
-		opts := &ServiceOpts{
-			Traffic: test.traffic,
+		svc := &run.Service{
+			Metadata: &run.ObjectMeta{},
+			Spec: &run.ServiceSpec{
+				Traffic: test.traffic,
+			},
 		}
-		svc := generateService(opts)
-		svcRecord := &rollout.ServiceRecord{Service: svc}
+		svcRecord := &ServiceRecord{Service: svc}
 
-		r := rollout.New(context.TODO(), metricsMock, svcRecord, strategy).WithClient(runclient)
+		r := New(context.TODO(), metricsMock, svcRecord, strategy).WithClient(runclient)
 
 		t.Run(test.name, func(tt *testing.T) {
-			traffic := r.RollForwardTraffic(svc.Spec.Traffic, test.stable, test.candidate)
+			traffic := r.rollForwardTraffic(svc.Spec.Traffic, test.stable, test.candidate)
 			assert.Equal(tt, test.expected, traffic)
 		})
 	}
@@ -143,22 +144,27 @@ func TestRollbackTraffic(t *testing.T) {
 	stable := "test-001"
 	candidate := "test-003"
 	traffic := []*run.TrafficTarget{
-		{RevisionName: "test-001", Percent: 40, Tag: rollout.StableTag},
+		{RevisionName: "test-001", Percent: 40, Tag: StableTag},
 		{RevisionName: "test-002", Tag: "tag1"},
-		{RevisionName: "test-003", Percent: 60, Tag: rollout.CandidateTag},
+		{RevisionName: "test-003", Percent: 60, Tag: CandidateTag},
 		{RevisionName: "test-003", Tag: "tag2"},
 	}
 	expectedTraffic := []*run.TrafficTarget{
-		{RevisionName: "test-001", Percent: 100, Tag: rollout.StableTag},
-		{RevisionName: "test-003", Percent: 0, Tag: rollout.CandidateTag},
-		{LatestRevision: true, Tag: rollout.LatestTag},
+		{RevisionName: "test-001", Percent: 100, Tag: StableTag},
+		{RevisionName: "test-003", Percent: 0, Tag: CandidateTag},
+		{LatestRevision: true, Tag: LatestTag},
 		{RevisionName: "test-002", Tag: "tag1"},
 		{RevisionName: "test-003", Tag: "tag2"},
 	}
-	svc := generateService(&ServiceOpts{Traffic: traffic})
-	svcRecord := &rollout.ServiceRecord{Service: svc}
+	svc := &run.Service{
+		Metadata: &run.ObjectMeta{},
+		Spec: &run.ServiceSpec{
+			Traffic: traffic,
+		},
+	}
+	svcRecord := &ServiceRecord{Service: svc}
 
-	r := rollout.New(context.TODO(), metricsMock, svcRecord, config.Strategy{})
-	traffic = r.RollbackTraffic(svc.Spec.Traffic, stable, candidate)
+	r := New(context.TODO(), metricsMock, svcRecord, config.Strategy{})
+	traffic = r.rollbackTraffic(svc.Spec.Traffic, stable, candidate)
 	assert.Equal(t, expectedTraffic, traffic)
 }

--- a/internal/rollout/traffic_test.go
+++ b/internal/rollout/traffic_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/config"
 	metricsmock "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/metrics/mock"
 	runmock "github.com/GoogleCloudPlatform/cloud-run-release-operator/internal/run/mock"
-	"github.com/GoogleCloudPlatform/cloud-run-release-operator/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/run/v1"
 )


### PR DESCRIPTION
This creates a new file traffic.go and move all the traffic-related methods to the new file. It also refactors the methods to return traffic configuration, so the main caller, UpdateService, can update the service's traffic.
