### PR TITLE
main: Use time.Duration for time-related flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,8 @@ The rollout strategy consists of the steps and health criteria.
 
 - `-cli-run-interval`: The time between each health check (default: `60s`). This
 is only need it if running with `-cli` option.
-- `-healthcheck-offset`: The range of time for retrieving metrics relative to
-the current rollout process (default: `30m`). Default value means that metrics
-from the last 30 minutes are retrieved.
+- `-healthcheck-offset`: Time window to look back during health check to assess
+the candidate revision's health (default: `30m`).
 - `-min-requests`: The minimum number of requests needed to determine the
 candidate's health (default: `100`)
 - `-min-wait`: The minimum time before rolling out further (default: `30m`)

--- a/README.md
+++ b/README.md
@@ -188,10 +188,10 @@ available Cloud Run regions](https://cloud.google.com/run/docs/locations))
 
 The rollout strategy consists of the steps and health criteria.
 
-- `-cli-run-interval`: The time between each health check, in seconds (default:
-`60`). This is only need it if running with `-cli` option.
-- `-healthcheck-offset`: To evaluate the candidate's health, use metrics from
-the last `N` minutes relative to current rollout process (default: `30`)
+- `-cli-run-interval`: The time between each health check (default: `60s`). This
+is only need it if running with `-cli` option.
+- `-healthcheck-offset`:range of time for retrieving metrics relative to current
+rollout process (default: `30m`)
 - `-min-requests`: The minimum number of requests needed to determine the
 candidate's health (default: `100`)
 - `-min-wait`: The minimum time before rolling out further (default: `30m`)

--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ is only need it if running with `-cli` option.
 - `-healthcheck-offset`: Time window to look back during health check to assess
 the candidate revision's health (default: `30m`).
 - `-min-requests`: The minimum number of requests needed to determine the
-candidate's health (default: `100`)
+candidate's health (default: `100`). This minimum value is expected in the time
+window determined by `-healthcheck-offset`
 - `-min-wait`: The minimum time before rolling out further (default: `30m`)
 - `-steps`: Percentages of traffic the candidate should go through (default:
 `5,20,50,80`)

--- a/README.md
+++ b/README.md
@@ -190,8 +190,9 @@ The rollout strategy consists of the steps and health criteria.
 
 - `-cli-run-interval`: The time between each health check (default: `60s`). This
 is only need it if running with `-cli` option.
-- `-healthcheck-offset`:range of time for retrieving metrics relative to current
-rollout process (default: `30m`)
+- `-healthcheck-offset`: The range of time for retrieving metrics relative to
+the current rollout process (default: `30m`). Default value means that metrics
+from the last 30 minutes are retrieved.
 - `-min-requests`: The minimum number of requests needed to determine the
 candidate's health (default: `100`)
 - `-min-wait`: The minimum time before rolling out further (default: `30m`)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -98,7 +98,7 @@ func init() {
 	flag.StringVar(&flStepsString, "steps", "5,20,50,80", "define steps in one flag separated by commas (e.g. 5,30,60)")
 	flag.DurationVar(&flHealthOffset, "healthcheck-offset", 30*time.Minute, "time window to look back during health check to assess the candidate's health")
 	flag.DurationVar(&flTimeBeweenRollouts, "min-wait", 30*time.Minute, "minimum time to wait between rollout stages (in minutes), use 0 to disable")
-	flag.IntVar(&flMinRequestCount, "min-requests", 100, "expected minimum requests before determining candidate's health")
+	flag.IntVar(&flMinRequestCount, "min-requests", 100, "expected minimum requests (in time window given by -healthcheck-offset) needed to determine candidate's health")
 	flag.Float64Var(&flErrorRate, "max-error-rate", 1.0, "expected max server error rate (in percent)")
 	flag.Float64Var(&flLatencyP99, "latency-p99", 0, "expected max latency for 99th percentile of requests (set 0 to ignore)")
 	flag.Float64Var(&flLatencyP95, "latency-p95", 0, "expected max latency for 95th percentile of requests (set 0 to ignore)")

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -55,12 +55,12 @@ func (steps stepFlags) String() string {
 }
 
 var (
-	flLoggingLevel       string
-	flCLI                bool
-	flCLILoopIntervalSec int
-	flHTTPAddr           string
-	flProject            string
-	flLabelSelector      string
+	flLoggingLevel    string
+	flCLI             bool
+	flCLILoopInterval time.Duration
+	flHTTPAddr        string
+	flProject         string
+	flLabelSelector   string
 
 	// Empty array means all regions.
 	flRegions       []string
@@ -69,7 +69,7 @@ var (
 	// Rollout strategy-related flags.
 	flSteps              stepFlags
 	flStepsString        string
-	flHealthOffsetMinute int
+	flHealthOffset       time.Duration
 	flTimeBeweenRollouts time.Duration
 	flMinRequestCount    int
 	flErrorRate          float64
@@ -89,14 +89,14 @@ func init() {
 
 	flag.StringVar(&flLoggingLevel, "verbosity", "info", "the logging level (e.g. debug)")
 	flag.BoolVar(&flCLI, "cli", false, "run as CLI application to manage rollout in intervals")
-	flag.IntVar(&flCLILoopIntervalSec, "cli-run-interval", 60, "the time between each rollout process (in seconds)")
+	flag.DurationVar(&flCLILoopInterval, "cli-run-interval", 60*time.Second, "the time between each rollout process (in seconds)")
 	flag.StringVar(&flHTTPAddr, "http-addr", defaultAddr, "address where to listen to http requests (e.g. :8080)")
 	flag.StringVar(&flProject, "project", "", "project in which the service is deployed")
 	flag.StringVar(&flLabelSelector, "label", "rollout-strategy=gradual", "filter services based on a label (e.g. team=backend)")
 	flag.StringVar(&flRegionsString, "regions", "", "the Cloud Run regions where the services should be looked at")
 	flag.Var(&flSteps, "step", "a percentage in traffic the candidate should go through")
 	flag.StringVar(&flStepsString, "steps", "5,20,50,80", "define steps in one flag separated by commas (e.g. 5,30,60)")
-	flag.IntVar(&flHealthOffsetMinute, "healthcheck-offset", 30, "use metrics from the last N minutes relative to current rollout process")
+	flag.DurationVar(&flHealthOffset, "healthcheck-offset", 30*time.Minute, "range of time for retrieving metrics (relative to current rollout process)")
 	flag.DurationVar(&flTimeBeweenRollouts, "min-wait", 30*time.Minute, "minimum time to wait between rollout stages (in minutes), use 0 to disable")
 	flag.IntVar(&flMinRequestCount, "min-requests", 100, "expected minimum requests before determining candidate's health")
 	flag.Float64Var(&flErrorRate, "max-error-rate", 1.0, "expected max server error rate (in percent)")
@@ -129,8 +129,7 @@ func main() {
 		)
 	}
 
-	valid, err := flagsAreValid()
-	if !valid {
+	if err := validateFlags(); err != nil {
 		logger.Fatalf("invalid flags: %v", err)
 	}
 
@@ -138,7 +137,7 @@ func main() {
 	target := config.NewTarget(flProject, flRegions, flLabelSelector)
 	healthCriteria := healthCriteriaFromFlags(flMinRequestCount, flErrorRate, flLatencyP99, flLatencyP95, flLatencyP50)
 	printHealthCriteria(logger, healthCriteria)
-	strategy := config.NewStrategy(target, flSteps, flHealthOffsetMinute, flTimeBeweenRollouts, healthCriteria)
+	strategy := config.NewStrategy(target, flSteps, flHealthOffset, flTimeBeweenRollouts, healthCriteria)
 	cfg := &config.Config{Strategies: []config.Strategy{strategy}}
 	if err := cfg.Validate(); err != nil {
 		logger.Fatalf("invalid rollout configuration: %v", err)
@@ -163,12 +162,11 @@ func runDaemon(ctx context.Context, logger *logrus.Logger, cfg *config.Config) {
 			logger.Warnf("there were %d errors: \n%s", len(errs), errsStr)
 		}
 
-		duration := time.Duration(flCLILoopIntervalSec)
-		time.Sleep(duration * time.Second)
+		time.Sleep(flCLILoopInterval)
 	}
 }
 
-func flagsAreValid() (bool, error) {
+func validateFlags() error {
 	// -steps flag has precedence over the list of -step flags.
 	if flStepsString != "" {
 		steps := strings.Split(flStepsString, ",")
@@ -176,7 +174,7 @@ func flagsAreValid() (bool, error) {
 		for _, step := range steps {
 			value, err := strconv.ParseInt(step, 10, 64)
 			if err != nil {
-				return false, errors.Wrap(err, "invalid step value")
+				return errors.Wrapf(err, "invalid step value %v", value)
 			}
 
 			flSteps = append(flSteps, value)
@@ -185,11 +183,17 @@ func flagsAreValid() (bool, error) {
 
 	for _, region := range flRegions {
 		if region == "" {
-			return false, errors.New("region cannot be empty")
+			return errors.New("regions cannot be empty")
 		}
 	}
 
-	return true, nil
+	if flHealthOffset < 0 {
+		return errors.Errorf("health check offset cannot be negative, got %s", flHealthOffset)
+	}
+	if flCLILoopInterval < 0 {
+		return errors.Errorf("cli run interval cannot be negative, got %s", flCLILoopInterval)
+	}
+	return nil
 }
 
 // chooseMetricsProvider checks the CLI flags and determine which metrics

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -187,9 +187,6 @@ func validateFlags() error {
 		}
 	}
 
-	if flHealthOffset < 0 {
-		return errors.Errorf("health check offset cannot be negative, got %s", flHealthOffset)
-	}
 	if flCLILoopInterval < 0 {
 		return errors.Errorf("cli run interval cannot be negative, got %s", flCLILoopInterval)
 	}

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -96,7 +96,7 @@ func init() {
 	flag.StringVar(&flRegionsString, "regions", "", "the Cloud Run regions where the services should be looked at")
 	flag.Var(&flSteps, "step", "a percentage in traffic the candidate should go through")
 	flag.StringVar(&flStepsString, "steps", "5,20,50,80", "define steps in one flag separated by commas (e.g. 5,30,60)")
-	flag.DurationVar(&flHealthOffset, "healthcheck-offset", 30*time.Minute, "range of time for retrieving metrics (relative to current rollout process)")
+	flag.DurationVar(&flHealthOffset, "healthcheck-offset", 30*time.Minute, "time window to look back during health check to assess the candidate's health")
 	flag.DurationVar(&flTimeBeweenRollouts, "min-wait", 30*time.Minute, "minimum time to wait between rollout stages (in minutes), use 0 to disable")
 	flag.IntVar(&flMinRequestCount, "min-requests", 100, "expected minimum requests before determining candidate's health")
 	flag.Float64Var(&flErrorRate, "max-error-rate", 1.0, "expected max server error rate (in percent)")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,7 +44,7 @@ type Strategy struct {
 	Target              Target
 	Steps               []int64
 	HealthCriteria      []HealthCriterion
-	HealthOffsetMinute  int
+	HealthCheckOffset   time.Duration
 	TimeBetweenRollouts time.Duration
 }
 
@@ -63,12 +63,12 @@ func NewTarget(project string, regions []string, labelSelector string) Target {
 }
 
 // NewStrategy initializes a strategy.
-func NewStrategy(target Target, steps []int64, healthOffset int, timeBetweenRollouts time.Duration, healthCriteria []HealthCriterion) Strategy {
+func NewStrategy(target Target, steps []int64, healthOffset, timeBetweenRollouts time.Duration, healthCriteria []HealthCriterion) Strategy {
 	return Strategy{
 		Target:              target,
 		Steps:               steps,
 		HealthCriteria:      healthCriteria,
-		HealthOffsetMinute:  healthOffset,
+		HealthCheckOffset:   healthOffset,
 		TimeBetweenRollouts: timeBetweenRollouts,
 	}
 }
@@ -86,8 +86,8 @@ func (config Config) Validate() error {
 
 // Validate checks if the strategy is valid.
 func (strategy Strategy) Validate() error {
-	if strategy.HealthOffsetMinute <= 0 {
-		return errors.Errorf("health check offset must be positive, got %d", strategy.HealthOffsetMinute)
+	if strategy.HealthCheckOffset <= 0 {
+		return errors.Errorf("health check offset must be positive, got %d", strategy.HealthCheckOffset)
 	}
 
 	if len(strategy.Steps) == 0 {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -13,7 +13,7 @@ func TestStrategy_Validate(t *testing.T) {
 		name                string
 		target              config.Target
 		steps               []int64
-		healthOffset        int
+		healthOffset        time.Duration
 		timeBetweenRollouts time.Duration
 		healthCriteria      []config.HealthCriterion
 		shouldErr           bool
@@ -22,7 +22,7 @@ func TestStrategy_Validate(t *testing.T) {
 			name:                "correct config with label selector",
 			target:              config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
 			steps:               []int64{5, 30, 60},
-			healthOffset:        20,
+			healthOffset:        10 * time.Minute,
 			timeBetweenRollouts: 10 * time.Minute,
 			healthCriteria: []config.HealthCriterion{
 				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
@@ -34,7 +34,7 @@ func TestStrategy_Validate(t *testing.T) {
 			name:                "missing project",
 			target:              config.NewTarget("", []string{"us-east1", "us-west1"}, "team=backend"),
 			steps:               []int64{5, 30, 60},
-			healthOffset:        20,
+			healthOffset:        10 * time.Minute,
 			timeBetweenRollouts: 10 * time.Minute,
 			healthCriteria:      nil,
 			shouldErr:           true,
@@ -43,7 +43,7 @@ func TestStrategy_Validate(t *testing.T) {
 			name:                "missing steps",
 			target:              config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
 			steps:               []int64{},
-			healthOffset:        20,
+			healthOffset:        10 * time.Minute,
 			timeBetweenRollouts: 10 * time.Minute,
 			shouldErr:           true,
 		},
@@ -51,7 +51,7 @@ func TestStrategy_Validate(t *testing.T) {
 			name:                "steps not in order",
 			target:              config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
 			steps:               []int64{30, 30, 60},
-			healthOffset:        20,
+			healthOffset:        10 * time.Minute,
 			timeBetweenRollouts: 10 * time.Minute,
 			shouldErr:           true,
 		},

--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -370,10 +370,10 @@ func (r *Rollout) setHealthReportAnnotation(svc *run.Service, report string) {
 
 // diagnoseCandidate returns the candidate's diagnosis based on metrics.
 func (r *Rollout) diagnoseCandidate(candidate string, healthCriteria []config.HealthCriterion) (d health.Diagnosis, err error) {
-	healthCheckOffset := time.Duration(r.strategy.HealthOffsetMinute) * time.Minute
 	r.log.Debug("collecting metrics from API")
 	ctx := util.ContextWithLogger(r.ctx, r.log)
 	r.metricsProvider.SetCandidateRevision(candidate)
+	healthCheckOffset := r.strategy.HealthCheckOffset
 	metricsValues, err := health.CollectMetrics(ctx, r.metricsProvider, healthCheckOffset, healthCriteria)
 	if err != nil {
 		return d, errors.Wrap(err, "failed to collect metrics")

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -2,6 +2,7 @@ package rollout_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -2,7 +2,6 @@ package rollout_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -61,7 +60,7 @@ func TestUpdateService(t *testing.T) {
 	metricsMock.SetCandidateRevisionFn = func(revisionName string) {}
 	strategy := config.Strategy{
 		Steps:               []int64{10, 40, 70},
-		HealthOffsetMinute:  5,
+		HealthCheckOffset:   5 * time.Minute,
 		TimeBetweenRollouts: 10 * time.Minute,
 	}
 


### PR DESCRIPTION
This updates the type expected by the `cli-run-interval` and `healthcheck-offset` flags to time.Duration. This makes it more logical to the user and simplify our current implementation.