### PR TITLE
config: Allow multiple strategies

### DIFF
--- a/cmd/operator/server.go
+++ b/cmd/operator/server.go
@@ -12,7 +12,8 @@ import (
 func makeRolloutHandler(logger *logrus.Logger, cfg *config.Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
-		errs := runRollouts(ctx, logger, cfg)
+		// TODO(gvso): Handle all the strategies.
+		errs := runRollouts(ctx, logger, cfg.Strategies[0])
 		errsStr := rolloutErrsToString(errs)
 		if len(errs) != 0 {
 			msg := fmt.Sprintf("there were %d errors: \n%s", len(errs), errsStr)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,115 +31,117 @@ type Target struct {
 	LabelSelector string
 }
 
-// Metric is a metrics threshold that should be met to consider a candidate
-// healthy.
-type Metric struct {
-	Type       MetricsCheck
+// HealthCriterion is a metrics threshold that should be met to consider a
+// candidate healthy.
+type HealthCriterion struct {
+	Metric     MetricsCheck
 	Percentile float64
 	Threshold  float64
 }
 
-// Strategy is the steps and configuration for rollout.
+// Strategy is a rollout configuration for the targeted services.
 type Strategy struct {
+	Target              Target
 	Steps               []int64
-	HealthCriteria      []Metric
+	HealthCriteria      []HealthCriterion
 	HealthOffsetMinute  int
 	TimeBetweenRollouts time.Duration
 }
 
 // Config contains the configuration for the application.
-//
-// It is the configuration for entire process for all the possible services that
-// are selected through the targets field.
 type Config struct {
-	Targets  []*Target
-	Strategy *Strategy
-}
-
-// New initializes a configuration.
-func New(targets []*Target, steps []int64, healthOffset int, timeBetweenRollouts time.Duration, metrics []Metric) *Config {
-	return &Config{
-		Targets: targets,
-		Strategy: &Strategy{
-			Steps:               steps,
-			HealthCriteria:      metrics,
-			HealthOffsetMinute:  healthOffset,
-			TimeBetweenRollouts: timeBetweenRollouts,
-		},
-	}
+	Strategies []Strategy
 }
 
 // NewTarget initializes a target to filter services by label.
-func NewTarget(project string, regions []string, labelSelector string) *Target {
-	return &Target{
+func NewTarget(project string, regions []string, labelSelector string) Target {
+	return Target{
 		Project:       project,
 		Regions:       regions,
 		LabelSelector: labelSelector,
 	}
 }
 
+// NewStrategy initializes a strategy.
+func NewStrategy(target Target, steps []int64, healthOffset int, timeBetweenRollouts time.Duration, healthCriteria []HealthCriterion) Strategy {
+	return Strategy{
+		Target:              target,
+		Steps:               steps,
+		HealthCriteria:      healthCriteria,
+		HealthOffsetMinute:  healthOffset,
+		TimeBetweenRollouts: timeBetweenRollouts,
+	}
+}
+
 // Validate checks if the configuration is valid.
-func (config *Config) Validate() error {
-	if config.Strategy.HealthOffsetMinute <= 0 {
-		return errors.Errorf("health check offset must be positive, got %d", config.Strategy.HealthOffsetMinute)
+func (config Config) Validate() error {
+	for i, strategy := range config.Strategies {
+		err := strategy.Validate()
+		if err != nil {
+			return errors.Wrapf(err, "invalid strategy at index %d", i)
+		}
+	}
+	return nil
+}
+
+// Validate checks if the strategy is valid.
+func (strategy Strategy) Validate() error {
+	if strategy.HealthOffsetMinute <= 0 {
+		return errors.Errorf("health check offset must be positive, got %d", strategy.HealthOffsetMinute)
 	}
 
-	if len(config.Strategy.Steps) == 0 {
+	if len(strategy.Steps) == 0 {
 		return errors.New("steps cannot be empty")
 	}
 
 	// Steps must be in ascending order and not greater than 100.
 	var previous int64
-	for _, step := range config.Strategy.Steps {
+	for _, step := range strategy.Steps {
 		if step <= previous || step > 100 {
 			return errors.New("steps must be in ascending order and not greater than 100")
 		}
 		previous = step
 	}
 
-	for i, criteria := range config.Strategy.HealthCriteria {
-		if err := validateMetrics(criteria); err != nil {
-			return errors.Wrapf(err, "invalid metrics criteria at index %d", i)
+	for i, criterion := range strategy.HealthCriteria {
+		if err := validateHealthCriterion(criterion); err != nil {
+			return errors.Wrapf(err, "invalid metrics criterion at index %d", i)
 		}
 	}
-	return validateTargets(config.Targets)
+	return validateTarget(strategy.Target)
 }
 
-func validateMetrics(metricsCriteria Metric) error {
-	threshold := metricsCriteria.Threshold
+func validateHealthCriterion(criterion HealthCriterion) error {
+	threshold := criterion.Threshold
 	if threshold < 0 {
-		return errors.Errorf("threshold cannot be negative, criteria %q", metricsCriteria.Type)
+		return errors.Errorf("threshold cannot be negative, criterion %q", criterion.Metric)
 	}
 
-	switch metricsCriteria.Type {
+	switch criterion.Metric {
 	case ErrorRateMetricsCheck:
 		if threshold > 100 {
-			return errors.Errorf("threshold must be greater than 0 and less than 100 for %q", metricsCriteria.Type)
+			return errors.Errorf("threshold must be greater than 0 and less than 100 for %q", criterion.Metric)
 		}
 	case LatencyMetricsCheck:
-		percentile := metricsCriteria.Percentile
+		percentile := criterion.Percentile
 		if percentile != 99 && percentile != 95 && percentile != 50 {
-			return errors.Errorf("invalid percentile for %q", metricsCriteria.Type)
+			return errors.Errorf("invalid percentile for %.2f", criterion.Percentile)
 		}
 	case RequestCountMetricsCheck:
 		return nil
 	default:
-		return errors.Errorf("invalid metric criteria %q", metricsCriteria.Type)
+		return errors.Errorf("invalid metric criteria %q", criterion.Metric)
 	}
 
 	return nil
 }
 
-func validateTargets(targets []*Target) error {
-	for i, target := range targets {
-		if target.Project == "" {
-			return errors.Errorf("project must be specified in target at index %d", i)
-		}
-
-		if target.LabelSelector == "" {
-			return errors.Errorf("label must be specified in target at index %d", i)
-		}
+func validateTarget(target Target) error {
+	if target.Project == "" {
+		return errors.Errorf("project must be specified")
 	}
-
+	if target.LabelSelector == "" {
+		return errors.Errorf("label must be specified")
+	}
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8,145 +8,118 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsValid(t *testing.T) {
+func TestStrategy_Validate(t *testing.T) {
 	tests := []struct {
 		name                string
-		targets             []*config.Target
+		target              config.Target
 		steps               []int64
 		healthOffset        int
 		timeBetweenRollouts time.Duration
-		metrics             []config.Metric
+		healthCriteria      []config.HealthCriterion
 		shouldErr           bool
 	}{
 		{
-			name: "correct config with label selector",
-			targets: []*config.Target{
-				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
-			},
+			name:                "correct config with label selector",
+			target:              config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
 			steps:               []int64{5, 30, 60},
 			healthOffset:        20,
 			timeBetweenRollouts: 10 * time.Minute,
-			metrics: []config.Metric{
-				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
-				{Type: config.RequestCountMetricsCheck, Threshold: 1000},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
+				{Metric: config.RequestCountMetricsCheck, Threshold: 1000},
 			},
 			shouldErr: false,
 		},
 		{
-			name: "missing project",
-			targets: []*config.Target{
-				config.NewTarget("", []string{"us-east1", "us-west1"}, "team=backend"),
-			},
+			name:                "missing project",
+			target:              config.NewTarget("", []string{"us-east1", "us-west1"}, "team=backend"),
 			steps:               []int64{5, 30, 60},
 			healthOffset:        20,
 			timeBetweenRollouts: 10 * time.Minute,
-			metrics:             nil,
+			healthCriteria:      nil,
 			shouldErr:           true,
 		},
 		{
-			name: "missing steps",
-			targets: []*config.Target{
-				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
-			},
+			name:                "missing steps",
+			target:              config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
 			steps:               []int64{},
 			healthOffset:        20,
 			timeBetweenRollouts: 10 * time.Minute,
-			metrics:             nil,
 			shouldErr:           true,
 		},
 		{
-			name: "steps not in order",
-			targets: []*config.Target{
-				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
-			},
+			name:                "steps not in order",
+			target:              config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
 			steps:               []int64{30, 30, 60},
 			healthOffset:        20,
 			timeBetweenRollouts: 10 * time.Minute,
-			metrics:             nil,
 			shouldErr:           true,
 		},
 		{
-			name: "step greater than 100",
-			targets: []*config.Target{
-				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
-			},
+			name:                "step greater than 100",
+			target:              config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
 			steps:               []int64{5, 30, 101},
 			healthOffset:        20,
 			timeBetweenRollouts: 10 * time.Minute,
-			metrics:             nil,
 			shouldErr:           true,
 		},
 		{
-			name: "non-positive health offset",
-			targets: []*config.Target{
-				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
-			},
+			name:                "non-positive health offset",
+			target:              config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
 			steps:               []int64{5, 30, 60},
 			healthOffset:        0,
 			timeBetweenRollouts: 10 * time.Minute,
-			metrics:             nil,
 			shouldErr:           true,
 		},
 		{
-			name: "empty label selector",
-			targets: []*config.Target{
-				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, ""),
-			},
+			name:                "empty label selector",
+			target:              config.NewTarget("myproject", []string{"us-east1", "us-west1"}, ""),
 			steps:               []int64{5, 30, 60},
 			healthOffset:        20,
 			timeBetweenRollouts: 10 * time.Minute,
-			metrics:             nil,
 			shouldErr:           true,
 		},
 		{
-			name: "invalid request count value",
-			targets: []*config.Target{
-				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
-			},
+			name:                "invalid request count value",
+			target:              config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
 			steps:               []int64{5, 30, 60},
 			healthOffset:        20,
 			timeBetweenRollouts: 10 * time.Minute,
-			metrics: []config.Metric{
-				{Type: config.RequestCountMetricsCheck, Threshold: -1},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.RequestCountMetricsCheck, Threshold: -1},
 			},
 			shouldErr: true,
 		},
 		{
-			name: "invalid error rate in metrics",
-			targets: []*config.Target{
-				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
-			},
+			name:                "invalid error rate in criteria",
+			target:              config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
 			steps:               []int64{5, 30, 60},
 			healthOffset:        20,
 			timeBetweenRollouts: 10 * time.Minute,
-			metrics: []config.Metric{
-				{Type: config.ErrorRateMetricsCheck, Threshold: 101},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.ErrorRateMetricsCheck, Threshold: 101},
 			},
 			shouldErr: true,
 		},
 		{
-			name: "invalid latency percentile",
-			targets: []*config.Target{
-				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
-			},
+			name:                "invalid latency percentile",
+			target:              config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
 			steps:               []int64{5, 30, 60},
 			healthOffset:        20,
 			timeBetweenRollouts: 10 * time.Minute,
-			metrics: []config.Metric{
-				{Type: config.LatencyMetricsCheck, Percentile: 98},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.LatencyMetricsCheck, Percentile: 98},
 			},
 			shouldErr: true,
 		},
 		{
-			name: "invalid latency value",
-			targets: []*config.Target{
-				config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
-			},
+			name:                "invalid latency value",
+			target:              config.NewTarget("myproject", []string{"us-east1", "us-west1"}, "team=backend"),
 			steps:               []int64{5, 30, 60},
 			healthOffset:        20,
 			timeBetweenRollouts: 10 * time.Minute,
-			metrics: []config.Metric{
-				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: -1},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: -1},
 			},
 			shouldErr: true,
 		},
@@ -154,8 +127,8 @@ func TestIsValid(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			config := config.New(test.targets, test.steps, test.healthOffset, test.timeBetweenRollouts, test.metrics)
-			err := config.Validate()
+			strategy := config.NewStrategy(test.target, test.steps, test.healthOffset, test.timeBetweenRollouts, test.healthCriteria)
+			err := strategy.Validate()
 			if test.shouldErr {
 				assert.NotNil(tt, err)
 			} else {

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -15,16 +15,16 @@ import (
 func TestDiagnosis(t *testing.T) {
 	tests := []struct {
 		name           string
-		healthCriteria []config.Metric
+		healthCriteria []config.HealthCriterion
 		results        []float64
 		expected       health.Diagnosis
 		shouldErr      bool
 	}{
 		{
 			name: "healthy revision",
-			healthCriteria: []config.Metric{
-				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
-				{Type: config.ErrorRateMetricsCheck, Threshold: 5},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
+				{Metric: config.ErrorRateMetricsCheck, Threshold: 5},
 			},
 			results: []float64{500.0, 1.0},
 			expected: health.Diagnosis{
@@ -37,9 +37,9 @@ func TestDiagnosis(t *testing.T) {
 		},
 		{
 			name: "barely healthy revision",
-			healthCriteria: []config.Metric{
-				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 500},
-				{Type: config.ErrorRateMetricsCheck, Threshold: 1},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 500},
+				{Metric: config.ErrorRateMetricsCheck, Threshold: 1},
 			},
 			results: []float64{500.0, 1.0},
 			expected: health.Diagnosis{
@@ -52,9 +52,9 @@ func TestDiagnosis(t *testing.T) {
 		},
 		{
 			name: "no enough requests, inconclusive",
-			healthCriteria: []config.Metric{
-				{Type: config.RequestCountMetricsCheck, Threshold: 1000},
-				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 500},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.RequestCountMetricsCheck, Threshold: 1000},
+				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 500},
 			},
 			results: []float64{800, 750.0},
 			expected: health.Diagnosis{
@@ -64,8 +64,8 @@ func TestDiagnosis(t *testing.T) {
 		},
 		{
 			name: "only request count criteria, unknown",
-			healthCriteria: []config.Metric{
-				{Type: config.RequestCountMetricsCheck, Threshold: 1000},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.RequestCountMetricsCheck, Threshold: 1000},
 			},
 			results: []float64{1500},
 			expected: health.Diagnosis{
@@ -77,8 +77,8 @@ func TestDiagnosis(t *testing.T) {
 		},
 		{
 			name: "unhealthy revision, miss latency",
-			healthCriteria: []config.Metric{
-				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 499},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 499},
 			},
 			results: []float64{500.0},
 			expected: health.Diagnosis{
@@ -90,8 +90,8 @@ func TestDiagnosis(t *testing.T) {
 		},
 		{
 			name: "unhealthy revision, miss error rate",
-			healthCriteria: []config.Metric{
-				{Type: config.ErrorRateMetricsCheck, Threshold: 0.95},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.ErrorRateMetricsCheck, Threshold: 0.95},
 			},
 			results: []float64{1.0},
 			expected: health.Diagnosis{
@@ -103,9 +103,9 @@ func TestDiagnosis(t *testing.T) {
 		},
 		{
 			name: "zero threshold",
-			healthCriteria: []config.Metric{
-				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 0},
-				{Type: config.ErrorRateMetricsCheck, Threshold: 0},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 0},
+				{Metric: config.ErrorRateMetricsCheck, Threshold: 0},
 			},
 			results: []float64{500.0, 1.0},
 			expected: health.Diagnosis{
@@ -118,9 +118,9 @@ func TestDiagnosis(t *testing.T) {
 		},
 		{
 			name: "zero metrics values",
-			healthCriteria: []config.Metric{
-				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
-				{Type: config.ErrorRateMetricsCheck, Threshold: 5},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
+				{Metric: config.ErrorRateMetricsCheck, Threshold: 5},
 			},
 			results: []float64{0, 0},
 			expected: health.Diagnosis{
@@ -133,8 +133,8 @@ func TestDiagnosis(t *testing.T) {
 		},
 		{
 			name: "should err, different sizes for criteria and results",
-			healthCriteria: []config.Metric{
-				{Type: config.ErrorRateMetricsCheck, Threshold: 0.95},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.ErrorRateMetricsCheck, Threshold: 0.95},
 			},
 			results:   []float64{},
 			shouldErr: true,
@@ -174,10 +174,10 @@ func TestCollectMetrics(t *testing.T) {
 
 	ctx := context.Background()
 	offset := 5 * time.Minute
-	healthCriteria := []config.Metric{
-		{Type: config.RequestCountMetricsCheck},
-		{Type: config.LatencyMetricsCheck, Percentile: 99},
-		{Type: config.ErrorRateMetricsCheck},
+	healthCriteria := []config.HealthCriterion{
+		{Metric: config.RequestCountMetricsCheck},
+		{Metric: config.LatencyMetricsCheck, Percentile: 99},
+		{Metric: config.ErrorRateMetricsCheck},
 	}
 	expected := []float64{1000, 500.0, 1.0}
 

--- a/pkg/health/report.go
+++ b/pkg/health/report.go
@@ -7,24 +7,24 @@ import (
 )
 
 // StringReport returns a human-readable report of the diagnosis.
-func StringReport(healthCriteria []config.Metric, diagnosis Diagnosis) string {
+func StringReport(healthCriteria []config.HealthCriterion, diagnosis Diagnosis) string {
 	report := fmt.Sprintf("status: %s\n", diagnosis.OverallResult.String())
 	report += "metrics:"
 	for i, result := range diagnosis.CheckResults {
 		criteria := healthCriteria[i]
 
 		// Include percentile value for latency criteria.
-		if criteria.Type == config.LatencyMetricsCheck {
-			report += fmt.Sprintf("\n- %s[p%.0f]: %.2f (needs %.2f)", criteria.Type, criteria.Percentile, result.ActualValue, criteria.Threshold)
+		if criteria.Metric == config.LatencyMetricsCheck {
+			report += fmt.Sprintf("\n- %s[p%.0f]: %.2f (needs %.2f)", criteria.Metric, criteria.Percentile, result.ActualValue, criteria.Threshold)
 			continue
 		}
 
 		format := "\n- %s: %.2f (needs %.2f)"
-		if criteria.Type == config.RequestCountMetricsCheck {
+		if criteria.Metric == config.RequestCountMetricsCheck {
 			// No decimals for request count.
 			format = "\n- %s: %.0f (needs %.0f)"
 		}
-		report += fmt.Sprintf(format, criteria.Type, result.ActualValue, criteria.Threshold)
+		report += fmt.Sprintf(format, criteria.Metric, result.ActualValue, criteria.Threshold)
 	}
 
 	return report

--- a/pkg/health/report_test.go
+++ b/pkg/health/report_test.go
@@ -11,14 +11,14 @@ import (
 func TestStringReport(t *testing.T) {
 	tests := []struct {
 		name           string
-		healthCriteria []config.Metric
+		healthCriteria []config.HealthCriterion
 		diagnosis      health.Diagnosis
 		expected       string
 	}{
 		{
 			name: "single metrics",
-			healthCriteria: []config.Metric{
-				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
 			},
 			diagnosis: health.Diagnosis{
 				OverallResult: health.Unhealthy,
@@ -32,10 +32,10 @@ func TestStringReport(t *testing.T) {
 		},
 		{
 			name: "more than one metrics",
-			healthCriteria: []config.Metric{
-				{Type: config.RequestCountMetricsCheck, Threshold: 1000},
-				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
-				{Type: config.ErrorRateMetricsCheck, Threshold: 5},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.RequestCountMetricsCheck, Threshold: 1000},
+				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
+				{Metric: config.ErrorRateMetricsCheck, Threshold: 5},
 			},
 			diagnosis: health.Diagnosis{
 				OverallResult: health.Healthy,

--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -40,7 +40,7 @@ type Rollout struct {
 	serviceName     string
 	project         string
 	region          string
-	strategy        *config.Strategy
+	strategy        config.Strategy
 	runClient       runapi.Client
 	log             *logrus.Entry
 	time            clockwork.Clock
@@ -60,7 +60,7 @@ const (
 )
 
 // New returns a new rollout manager.
-func New(ctx context.Context, metricsProvider metrics.Provider, svcRecord *ServiceRecord, strategy *config.Strategy) *Rollout {
+func New(ctx context.Context, metricsProvider metrics.Provider, svcRecord *ServiceRecord, strategy config.Strategy) *Rollout {
 	logger := logrus.New()
 	logger.SetOutput(ioutil.Discard)
 
@@ -364,7 +364,7 @@ func setAnnotation(svc *run.Service, key, value string) {
 }
 
 // diagnoseCandidate returns the candidate's diagnosis based on metrics.
-func (r *Rollout) diagnoseCandidate(candidate string, healthCriteria []config.Metric) (d health.Diagnosis, err error) {
+func (r *Rollout) diagnoseCandidate(candidate string, healthCriteria []config.HealthCriterion) (d health.Diagnosis, err error) {
 	healthCheckOffset := time.Duration(r.strategy.HealthOffsetMinute) * time.Minute
 	r.log.Debug("collecting metrics from API")
 	ctx := util.ContextWithLogger(r.ctx, r.log)

--- a/pkg/rollout/rollout_internal_test.go
+++ b/pkg/rollout/rollout_internal_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNextCandidateTraffic100(t *testing.T) {
-	strategy := &config.Strategy{
+	strategy := config.Strategy{
 		Steps: []int64{5, 30, 60},
 	}
 	r := &Rollout{strategy: strategy}

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -59,7 +59,7 @@ func TestUpdateService(t *testing.T) {
 		return 0.01, nil
 	}
 	metricsMock.SetCandidateRevisionFn = func(revisionName string) {}
-	strategy := &config.Strategy{
+	strategy := config.Strategy{
 		Steps:               []int64{10, 40, 70},
 		HealthOffsetMinute:  5,
 		TimeBetweenRollouts: 10 * time.Minute,
@@ -75,7 +75,7 @@ func TestUpdateService(t *testing.T) {
 
 		// See the metrics mock to know what would make the diagnosis the needed
 		// value for testing.
-		healthCriteria []config.Metric
+		healthCriteria []config.HealthCriterion
 		outAnnotations map[string]string
 		outTraffic     []*run.TrafficTarget
 		shouldErr      bool
@@ -89,9 +89,9 @@ func TestUpdateService(t *testing.T) {
 				{RevisionName: "test-003", Percent: 0, Tag: rollout.CandidateTag},
 			},
 			lastReady: "test-003",
-			healthCriteria: []config.Metric{
-				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
-				{Type: config.ErrorRateMetricsCheck, Threshold: 5},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
+				{Metric: config.ErrorRateMetricsCheck, Threshold: 5},
 			},
 			outAnnotations: map[string]string{
 				rollout.StableRevisionAnnotation:    "test-002",
@@ -152,9 +152,9 @@ func TestUpdateService(t *testing.T) {
 				rollout.LastRolloutAnnotation: makeLastRolloutAnnotation(clockMock, -30),
 			},
 			lastReady: "test-002",
-			healthCriteria: []config.Metric{
-				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
-				{Type: config.ErrorRateMetricsCheck, Threshold: 5},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
+				{Metric: config.ErrorRateMetricsCheck, Threshold: 5},
 			},
 			outAnnotations: map[string]string{
 				rollout.StableRevisionAnnotation:    "test-001",
@@ -182,9 +182,9 @@ func TestUpdateService(t *testing.T) {
 				rollout.LastRolloutAnnotation: makeLastRolloutAnnotation(clockMock, 0),
 			},
 			lastReady: "test-002",
-			healthCriteria: []config.Metric{
-				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
-				{Type: config.ErrorRateMetricsCheck, Threshold: 5},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
+				{Metric: config.ErrorRateMetricsCheck, Threshold: 5},
 			},
 			outAnnotations: map[string]string{
 				rollout.StableRevisionAnnotation:    "test-001",
@@ -228,9 +228,9 @@ func TestUpdateService(t *testing.T) {
 				rollout.LastRolloutAnnotation: makeLastRolloutAnnotation(clockMock, -30),
 			},
 			lastReady: "test-002",
-			healthCriteria: []config.Metric{
-				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
-				{Type: config.ErrorRateMetricsCheck, Threshold: 5},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
+				{Metric: config.ErrorRateMetricsCheck, Threshold: 5},
 			},
 			outAnnotations: map[string]string{
 				rollout.StableRevisionAnnotation: "test-002",
@@ -252,9 +252,9 @@ func TestUpdateService(t *testing.T) {
 				{RevisionName: "test-001", Percent: 80, Tag: rollout.StableTag},
 			},
 			lastReady: "test-002",
-			healthCriteria: []config.Metric{
-				{Type: config.LatencyMetricsCheck, Percentile: 99, Threshold: 100},
-				{Type: config.ErrorRateMetricsCheck, Threshold: 0.95},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 100},
+				{Metric: config.ErrorRateMetricsCheck, Threshold: 0.95},
 			},
 			outAnnotations: map[string]string{
 				rollout.StableRevisionAnnotation:              "test-001",
@@ -291,9 +291,9 @@ func TestUpdateService(t *testing.T) {
 				{RevisionName: "test-001", Percent: 80, Tag: rollout.StableTag},
 			},
 			lastReady: "test-002",
-			healthCriteria: []config.Metric{
-				{Type: config.RequestCountMetricsCheck, Threshold: 1500},
-				{Type: config.ErrorRateMetricsCheck, Threshold: 0.95},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.RequestCountMetricsCheck, Threshold: 1500},
+				{Metric: config.ErrorRateMetricsCheck, Threshold: 0.95},
 			},
 			nilService: true,
 		},
@@ -305,8 +305,8 @@ func TestUpdateService(t *testing.T) {
 				{RevisionName: "test-001", Percent: 80, Tag: rollout.StableTag},
 			},
 			lastReady: "test-002",
-			healthCriteria: []config.Metric{
-				{Type: config.RequestCountMetricsCheck, Threshold: 500},
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.RequestCountMetricsCheck, Threshold: 500},
 			},
 			shouldErr: true,
 		},
@@ -349,7 +349,7 @@ func TestUpdateService(t *testing.T) {
 func TestPrepareRollForward(t *testing.T) {
 	runclient := &runMocker.RunAPI{}
 	metricsMock := &metricsMocker.Metrics{}
-	strategy := &config.Strategy{
+	strategy := config.Strategy{
 		Steps: []int64{5, 30, 60},
 	}
 
@@ -497,7 +497,7 @@ func TestPrepareRollback(t *testing.T) {
 	svc := generateService(&ServiceOpts{Traffic: traffic})
 	svcRecord := &rollout.ServiceRecord{Service: svc}
 
-	r := rollout.New(context.TODO(), metricsMock, svcRecord, &config.Strategy{})
+	r := rollout.New(context.TODO(), metricsMock, svcRecord, config.Strategy{})
 	svc = r.PrepareRollback(svc, stable, candidate)
 	assert.Equal(t, expectedTraffic, svc.Spec.Traffic)
 }


### PR DESCRIPTION
As of now, the same rollout strategy was applied to all the targeted services. This makes changes to the configuration to allow different strategies for different targets.