### PR TITLE
main: Print all health criteria

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -231,13 +231,9 @@ func printHealthCriteria(logger *logrus.Logger, healthCriteria []config.HealthCr
 			"threshold":   criteria.Threshold,
 		})
 
-		switch criteria.Metric {
-		case config.ErrorRateMetricsCheck:
-			lg.Debug("found health criterion")
-		case config.LatencyMetricsCheck:
-			lg.WithField("percentile", criteria.Percentile).Debug("found health criterion")
-		default:
-			lg.Debug("invalid health criterion")
+		if criteria.Metric == config.LatencyMetricsCheck {
+			lg = lg.WithField("percentile", criteria.Percentile)
 		}
+		lg.Debug("found health criterion")
 	}
 }


### PR DESCRIPTION
This modifies printHealthCriteria to make it print all the health criteria passed to it. That is, it removes the switch statement with a default case printing "invalid criterion". This is useful since once more metrics are supported, we don't need to worry about this function. Validation is done a few statements later anyways.
